### PR TITLE
fix: Markdown  changed className

### DIFF
--- a/.changeset/gorgeous-adults-leave.md
+++ b/.changeset/gorgeous-adults-leave.md
@@ -1,0 +1,5 @@
+---
+'@yamada-ui/markdown': patch
+---
+
+Changed `className` in `Markdown`.

--- a/packages/components/markdown/src/markdown.tsx
+++ b/packages/components/markdown/src/markdown.tsx
@@ -92,7 +92,7 @@ const Code: FC<MarkdownComponentCodeProps & MarkdownOptions['code']> = ({
 }) => {
   if (inline)
     return (
-      <ui.code className={cx('ui-markdown-code', className)}>
+      <ui.code className={cx('ui-markdown__code--inline', className)}>
         {children}
       </ui.code>
     )
@@ -104,7 +104,7 @@ const Code: FC<MarkdownComponentCodeProps & MarkdownOptions['code']> = ({
   return (
     <ui.pre
       as={SyntaxHighlighter as any}
-      className={cx('ui-markdown-code', className)}
+      className={cx('ui-markdown__code', className)}
       language={language}
       style={(styles as any)[theme]}
     >


### PR DESCRIPTION
Related #193 <!-- Github issue # here -->

## Description

> Changed `className`

## Current behavior (updates)

> Nothing.

## New behavior

> Nothing.

## Is this a breaking change (Yes/No):

No.

## Additional Information
