### PR TITLE
fix: fixed placeholder in `MultiAutocomplete`

### DIFF
--- a/.changeset/heavy-geese-complain.md
+++ b/.changeset/heavy-geese-complain.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": minor
+---
+
+The issue where the `placeholder` isn't displaying has been resolved.

--- a/packages/components/autocomplete/src/multi-autocomplete.tsx
+++ b/packages/components/autocomplete/src/multi-autocomplete.tsx
@@ -308,7 +308,9 @@ const MultiAutocompleteField = forwardRef<MultiAutocompleteFieldProps, "div">(
             marginBlockStart="0.125rem"
             marginBlockEnd="0.125rem"
             placeholder={
-              !label || (keepPlaceholder && isOpen) ? placeholder : undefined
+              !label || !label?.length || (keepPlaceholder && isOpen)
+                ? placeholder
+                : undefined
             }
             {...getInputProps({ ...inputProps, value: inputValue ?? "" }, ref)}
           />


### PR DESCRIPTION
Closes #390 

## Description

> The bug causing the placeholder to disappear in MultiAutocomplete has been fixed.

## Current behavior (updates)

> The placeholder is disapper.

## New behavior

> The placeholder is apper.

## Is this a breaking change (Yes/No):

No.

## Additional Information

https://github.com/hirotomoyamada/yamada-ui/assets/60034520/054b26c0-c004-4c2f-b83f-52ffc9c34cb8



