### PR TITLE
Fixed `DatePicker` and `MonthPicker` value can't be cleared

### DIFF
--- a/.changeset/lucky-trains-compete.md
+++ b/.changeset/lucky-trains-compete.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-controllable-state": minor
+---
+
+Fixed a bug that when a value was set in the `DatePicker` or `MonthPicker` and the Clear button was clicked, the value should be cleared, but it was not.

--- a/packages/hooks/use-controllable-state/src/index.ts
+++ b/packages/hooks/use-controllable-state/src/index.ts
@@ -1,4 +1,9 @@
-import { useCallbackRef, runIfFunc } from "@yamada-ui/utils"
+import {
+  useCallbackRef,
+  runIfFunc,
+  isUndefined,
+  isNull,
+} from "@yamada-ui/utils"
 import type { Dispatch, SetStateAction } from "react"
 import { useState } from "react"
 
@@ -28,7 +33,8 @@ export const useControllableState = <T>({
 
       if (!onUpdate(resolvedValue, nextValue)) return
 
-      if (!controlled || !nextValue) setDefaultValue(nextValue)
+      if (!controlled || isUndefined(nextValue) || isNull(nextValue))
+        setDefaultValue(nextValue)
 
       onChange(nextValue)
     },

--- a/packages/hooks/use-controllable-state/src/index.ts
+++ b/packages/hooks/use-controllable-state/src/index.ts
@@ -28,7 +28,7 @@ export const useControllableState = <T>({
 
       if (!onUpdate(resolvedValue, nextValue)) return
 
-      if (!controlled) setDefaultValue(nextValue)
+      if (!controlled || !nextValue) setDefaultValue(nextValue)
 
       onChange(nextValue)
     },


### PR DESCRIPTION
Closes #398 #388

## Description

> Add a brief description

## Current behavior (updates)

> DatePicker and MonthPicker value can't be cleared

## New behavior

> DatePicker and MonthPicker value can be cleared

## Is this a breaking change (Yes/No):

No.

## Additional Information
