### PR TITLE
feat(slider): improved focus handling for sliders

### DIFF
--- a/.changeset/swift-hornets-buy.md
+++ b/.changeset/swift-hornets-buy.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/slider": patch
+---
+
+Improved focus logic for `slider` and `RangeSlider`.

--- a/packages/components/slider/src/range-slider.tsx
+++ b/packages/components/slider/src/range-slider.tsx
@@ -117,7 +117,12 @@ export type UseRangeSliderProps = FormControlOptions & {
   onChange?: (value: [number, number]) => void
 }
 
-export const useRangeSlider = (props: UseRangeSliderProps) => {
+export const useRangeSlider = ({
+  focusThumbOnChange = true,
+  ...props
+}: UseRangeSliderProps) => {
+  props.isReadOnly ??= !focusThumbOnChange
+
   let {
     id,
     name,
@@ -127,7 +132,6 @@ export const useRangeSlider = (props: UseRangeSliderProps) => {
     defaultValue,
     orientation = "horizontal",
     isReversed,
-    focusThumbOnChange = true,
     betweenThumbs = 0,
     required,
     disabled,
@@ -563,9 +567,11 @@ export const useRangeSlider = (props: UseRangeSliderProps) => {
         ...props,
         ref,
         id: getThumbId(i),
-        tabIndex: isInteractive ? 0 : undefined,
+        tabIndex: isInteractive && focusThumbOnChange ? 0 : undefined,
         role: "slider",
-        "data-active": dataAttr(isDragging && activeIndex === i),
+        "data-active": dataAttr(
+          isDragging && focusThumbOnChange && activeIndex === i,
+        ),
         "aria-orientation": orientation,
         onKeyDown: handlerAll(props.onKeyDown, onKeyDown),
         onFocus: handlerAll(props.onFocus, rest.onFocus, () => {
@@ -580,6 +586,7 @@ export const useRangeSlider = (props: UseRangeSliderProps) => {
       }
     },
     [
+      focusThumbOnChange,
       activeIndex,
       getThumbId,
       isDragging,

--- a/packages/components/slider/src/slider.tsx
+++ b/packages/components/slider/src/slider.tsx
@@ -109,8 +109,13 @@ export type UseSliderProps = FormControlOptions & {
   onChange?: (value: number) => void
 }
 
-export const useSlider = (props: UseSliderProps) => {
-  const {
+export const useSlider = ({
+  focusThumbOnChange = true,
+  ...props
+}: UseSliderProps) => {
+  props.isReadOnly ??= !focusThumbOnChange
+
+  let {
     id,
     name,
     min = 0,
@@ -119,7 +124,6 @@ export const useSlider = (props: UseSliderProps) => {
     defaultValue,
     orientation = "horizontal",
     isReversed,
-    focusThumbOnChange = true,
     required,
     disabled,
     readOnly,
@@ -456,9 +460,9 @@ export const useSlider = (props: UseSliderProps) => {
         ...pickObject(rest, formControlProperties),
         ...props,
         ref: mergeRefs(ref, thumbRef),
-        tabIndex: isInteractive ? 0 : undefined,
+        tabIndex: isInteractive && focusThumbOnChange ? 0 : undefined,
         role: "slider",
-        "data-active": dataAttr(isDragging),
+        "data-active": dataAttr(isDragging && focusThumbOnChange),
         "aria-orientation": orientation,
         onKeyDown: handlerAll(props.onKeyDown, onKeyDown),
         onFocus: handlerAll(props.onFocus, rest.onFocus, () =>
@@ -469,6 +473,7 @@ export const useSlider = (props: UseSliderProps) => {
       }
     },
     [
+      focusThumbOnChange,
       isDragging,
       isInteractive,
       isVertical,


### PR DESCRIPTION
Closes #372

## Description

Fixed an issue where the element was active even though `SliderThumb` input was disabled when `focusThumbOnChange` was set to `false`.

## Is this a breaking change 

No