### PR TITLE
feat: add `accent-color` property

### DIFF
--- a/.changeset/silly-oranges-move.md
+++ b/.changeset/silly-oranges-move.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": minor
+---
+
+Support `accent-color`.

--- a/packages/core/src/styles/interactivity.ts
+++ b/packages/core/src/styles/interactivity.ts
@@ -19,7 +19,7 @@ export type InteractivityProps = {
   /**
    * The CSS `accent-color` property.
    */
-  accentColor: Token<CSS.Property.AccentColor>
+  accentColor?: Token<CSS.Property.AccentColor, "colors">
   /**
    * The CSS `appearance` property.
    */

--- a/packages/core/src/styles/interactivity.ts
+++ b/packages/core/src/styles/interactivity.ts
@@ -16,6 +16,9 @@ export const interactivity: Configs = {
 }
 
 export type InteractivityProps = {
+  /**
+   * The CSS `accent-color` property.
+   */
   accentColor: Token<CSS.Property.AccentColor>
   /**
    * The CSS `appearance` property.

--- a/packages/core/src/styles/interactivity.ts
+++ b/packages/core/src/styles/interactivity.ts
@@ -4,6 +4,7 @@ import type { Configs } from "./config"
 import { configs } from "./config"
 
 export const interactivity: Configs = {
+  accentColor: configs.color("accentColor"),
   appearance: true,
   cursor: true,
   resize: true,
@@ -15,6 +16,7 @@ export const interactivity: Configs = {
 }
 
 export type InteractivityProps = {
+  accentColor: Token<CSS.Property.AccentColor>
   /**
    * The CSS `appearance` property.
    */


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #419 <!-- Github issue # here -->

## Description

> Support `accent-color` property

## Current behavior (updates)

> Nothing.

## New behavior

> able to use `accentColor`.

## Is this a breaking change (Yes/No):

No.

## Additional Information
