### PR TITLE
refactor(components): replace `onClick` with `onPointerDown`

### DIFF
--- a/.changeset/healthy-badgers-sparkle.md
+++ b/.changeset/healthy-badgers-sparkle.md
@@ -1,0 +1,9 @@
+---
+"@yamada-ui/close-button": patch
+"@yamada-ui/pagination": patch
+"@yamada-ui/button": patch
+"@yamada-ui/ripple": patch
+"@yamada-ui/tabs": patch
+---
+
+Replace `onClick` with `onPointerDown` on ripple effect.

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -98,7 +98,7 @@ export const Button = forwardRef<ButtonProps, "button">(
 
     const { ref: buttonRef, type: defaultType } = useButtonType(as)
     const ref = useMergeRefs(customRef, buttonRef)
-    const { onClick, ...rippleProps } = useRipple(rest)
+    const { onPointerDown, ...rippleProps } = useRipple(rest)
 
     const css: CSSUIObject = useMemo(() => {
       const _focus =
@@ -146,7 +146,7 @@ export const Button = forwardRef<ButtonProps, "button">(
         data__loading={dataAttr(isLoading)}
         __css={css}
         {...rest}
-        onClick={onClick}
+        onPointerDown={onPointerDown}
       >
         {isLoading && loadingPlacement === "start" ? (
           <Loading className="ui-button__loading--start" {...loadingProps} />

--- a/packages/components/close-button/src/close-button.tsx
+++ b/packages/components/close-button/src/close-button.tsx
@@ -33,7 +33,7 @@ export const CloseButton = forwardRef<CloseButtonProps, "button">(
     const [styles, mergedProps] = useComponentStyle("CloseButton", props)
     const { className, children, isDisabled, __css, disableRipple, ...rest } =
       omitThemeProps(mergedProps)
-    const { onClick, ...rippleProps } = useRipple(rest)
+    const { onPointerDown, ...rippleProps } = useRipple(rest)
 
     const css: CSSUIObject = {
       position: "relative",
@@ -56,7 +56,7 @@ export const CloseButton = forwardRef<CloseButtonProps, "button">(
         disabled={isDisabled}
         __css={css}
         {...rest}
-        onClick={onClick}
+        onPointerDown={onPointerDown}
       >
         {children || <CloseIcon width="1em" height="1em" />}
 

--- a/packages/components/pagination/src/pagination-item.tsx
+++ b/packages/components/pagination/src/pagination-item.tsx
@@ -61,7 +61,7 @@ export const PaginationItem: FC<PaginationItemProps> = ({
   ...rest
 }) => {
   const styles = usePaginationContext()
-  const { onClick, ...rippleProps } = useRipple(rest)
+  const { onPointerDown, ...rippleProps } = useRipple(rest)
 
   children ??= iconMap[page] ?? page
 
@@ -86,7 +86,7 @@ export const PaginationItem: FC<PaginationItemProps> = ({
       data-disabled={dataAttr(isDisabled)}
       __css={css}
       {...rest}
-      onClick={onClick}
+      onPointerDown={onPointerDown}
     >
       {children}
 

--- a/packages/components/ripple/src/use-ripple.ts
+++ b/packages/components/ripple/src/use-ripple.ts
@@ -1,6 +1,6 @@
 import { createId, handlerAll } from "@yamada-ui/utils"
 import type React from "react"
-import type { Key, MouseEventHandler } from "react"
+import type { Key, PointerEventHandler } from "react"
 import { useCallback, useState } from "react"
 
 export type RippleOptions = {
@@ -11,7 +11,7 @@ export type RippleOptions = {
 }
 
 export type UseRippleProps<T extends any = HTMLElement> = {
-  onClick?: MouseEventHandler<T>
+  onPointerDown?: PointerEventHandler<T>
 }
 
 export const useRipple = <T extends any = HTMLElement>(
@@ -19,7 +19,7 @@ export const useRipple = <T extends any = HTMLElement>(
 ) => {
   const [ripples, setRipples] = useState<RippleOptions[]>([])
 
-  const onClick: MouseEventHandler<T> = useCallback((ev) => {
+  const onPointerDown: PointerEventHandler<T> = useCallback((ev) => {
     const trigger = ev.currentTarget as unknown as Element
 
     const size = Math.max(trigger.clientWidth, trigger.clientHeight)
@@ -40,7 +40,11 @@ export const useRipple = <T extends any = HTMLElement>(
     setRipples((prev) => prev.filter((item) => item.key !== key))
   }, [])
 
-  return { ripples, onClick: handlerAll(onClick, props.onClick), onClear }
+  return {
+    ripples,
+    onPointerDown: handlerAll(onPointerDown, props.onPointerDown),
+    onClear,
+  }
 }
 
 export type UseRippleReturn = ReturnType<typeof useRipple>

--- a/packages/components/tabs/src/tab.tsx
+++ b/packages/components/tabs/src/tab.tsx
@@ -51,7 +51,7 @@ export const Tab = forwardRef<TabProps, "button">(
       clickOnSpace,
       onClick: handlerAll(props.onClick, () => setSelectedIndex(index)),
     })
-    const { onClick, ...rippleProps } = useRipple(rest)
+    const { onPointerDown, ...rippleProps } = useRipple(rest)
 
     const css: CSSUIObject = {
       position: "relative",
@@ -73,7 +73,7 @@ export const Tab = forwardRef<TabProps, "button">(
         type="button"
         tabIndex={isSelected ? 0 : -1}
         aria-selected={ariaAttr(isSelected)}
-        onClick={onClick}
+        onPointerDown={onPointerDown}
         onFocus={isDisabled ? undefined : handlerAll(props.onFocus, onFocus)}
       >
         {children}


### PR DESCRIPTION
Closes #466

## Description

The behavior of ripple effects such as `Button` components is strange.

## Current behavior (updates)

When you set a synchronous process such as `confirm` to `onClick` and click a `Button` component, the ripple effect is executed after confirmation.

## New behavior

Replace `onClick` with `onPointerDown`.

## Is this a breaking change 

No
