### PR TITLE
fix(autocomplete/calendar): disabled `Portal` props by default

### DIFF
--- a/.changeset/chatty-camels-ring.md
+++ b/.changeset/chatty-camels-ring.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/autocomplete": patch
+"@yamada-ui/calendar": patch
+---
+
+Disabled `Portal` props by default.

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -79,7 +79,7 @@ export const Autocomplete = forwardRef<AutocompleteProps, "input">(
       listProps,
       inputProps,
       iconProps,
-      portalProps = { isDisabled: false },
+      portalProps = { isDisabled: true },
       children,
       ...computedProps
     } = omitThemeProps(mergedProps)

--- a/packages/components/autocomplete/src/multi-autocomplete.tsx
+++ b/packages/components/autocomplete/src/multi-autocomplete.tsx
@@ -118,7 +118,7 @@ export const MultiAutocomplete = forwardRef<MultiAutocompleteProps, "div">(
       inputProps,
       iconProps,
       clearIconProps,
-      portalProps = { isDisabled: false },
+      portalProps = { isDisabled: true },
       children,
       ...computedProps
     } = omitThemeProps(mergedProps)

--- a/packages/components/calendar/src/date-picker.tsx
+++ b/packages/components/calendar/src/date-picker.tsx
@@ -73,7 +73,7 @@ export const DatePicker = forwardRef<DatePickerProps, "input">((props, ref) => {
     inputProps,
     iconProps,
     clearIconProps,
-    portalProps = { isDisabled: false },
+    portalProps = { isDisabled: true },
     ...computedProps
   } = omitThemeProps(mergedProps)
 

--- a/packages/components/calendar/src/month-picker.tsx
+++ b/packages/components/calendar/src/month-picker.tsx
@@ -74,7 +74,7 @@ export const MonthPicker = forwardRef<MonthPickerProps, "div">((props, ref) => {
     inputProps,
     iconProps,
     clearIconProps,
-    portalProps = { isDisabled: false },
+    portalProps = { isDisabled: true },
     ...computedProps
   } = omitThemeProps(mergedProps)
 


### PR DESCRIPTION
Closes #484

## Description

`MultiAutocomplete` component tries to close the list every time I select from it.

## Current behavior (updates)

When I click on an item in a list in a `MultiAutocomplete` component, I expected the list not to close, but the list tries to close on every click

## New behavior

Disabled `Portal` props by default.

## Is this a breaking change (Yes/No):

No