### PR TITLE
feat(theme): added `focusVisible` style to `CloseButton`

### DIFF
--- a/.changeset/lazy-garlics-brush.md
+++ b/.changeset/lazy-garlics-brush.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Added `focusVisible` style to `CloseButton`.

--- a/packages/theme/src/components/close-button.ts
+++ b/packages/theme/src/components/close-button.ts
@@ -9,6 +9,9 @@ export const CloseButton: ComponentStyle = mergeStyle(Button, {
     _active: {
       bg: ["blackAlpha.200", "whiteAlpha.200"],
     },
+    _focusVisible: {
+      boxShadow: "outline",
+    },
   },
 
   sizes: {


### PR DESCRIPTION
Closes #488

## Description

`CloseButton` focus outline not working.

## Current behavior (updates)

`CloseButton` component focus outline is not reflected correctly after sharing a theme with the `Button` component

## New behavior

Added focusVisible style to `CloseButton` component theme.

## Is this a breaking change (Yes/No):

No