### PR TITLE
feat(indicator): added `containerProps` support

### DIFF
--- a/.changeset/ten-vans-enjoy.md
+++ b/.changeset/ten-vans-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/indicator": minor
+---
+
+Added `containerProps` to `Indicator` component.

--- a/packages/components/indicator/src/indicator.tsx
+++ b/packages/components/indicator/src/indicator.tsx
@@ -72,6 +72,10 @@ type IndicatorOptions = {
    * @default false
    */
   withBorder?: boolean
+  /**
+   * Props for indicator wrapper element.
+   */
+  containerProps?: Omit<HTMLUIProps<"div">, "children">
 }
 
 export type IndicatorProps = Omit<HTMLUIProps<"div">, "children" | "offset"> &
@@ -133,6 +137,7 @@ export const Indicator = forwardRef<IndicatorProps, "div">((props, ref) => {
     showZero = true,
     children,
     isDisabled,
+    containerProps,
     ...rest
   } = omitThemeProps(mergedProps)
 
@@ -176,6 +181,7 @@ export const Indicator = forwardRef<IndicatorProps, "div">((props, ref) => {
         position: "relative",
         display: computedInline ? "inline-block" : "block",
       }}
+      {...containerProps}
     >
       {!isDisabled ? (
         <ui.div


### PR DESCRIPTION
Closes #493

## Description

Add `containerProps` to `Indicator` component

## Current behavior (updates)

Currently, no way to customize elements of the `Indicator` component wrapper.

## New behavior

Added `containerProps` to `Indicator` component.

## Is this a breaking change (Yes/No):

No