### PR TITLE
Feat/motion-config

### DIFF
--- a/.changeset/dirty-bikes-invent.md
+++ b/.changeset/dirty-bikes-invent.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/providers": patch
+"@yamada-ui/core": patch
+---
+
+Added `framer-motion` config support.

--- a/packages/core/src/theme.types.ts
+++ b/packages/core/src/theme.types.ts
@@ -1,6 +1,6 @@
 import type { PortalProps } from "@yamada-ui/portal"
 import type { Dict, StringLiteral } from "@yamada-ui/utils"
-import type { Variants } from "framer-motion"
+import type { MotionConfigProps, Variants } from "framer-motion"
 import type { FC, ReactNode } from "react"
 import type {
   UIStyle,
@@ -316,6 +316,17 @@ export type ThemeConfig = {
      * The options of the custom loading.
      */
     custom?: LoadingConfigOptions
+  }
+  /**
+   * The config of the `framer-motion`.
+   */
+  motion?: {
+    /**
+     * Set configuration options for `framer-motion`.
+     *
+     * @see Docs https://www.framer.com/motion/motion-config/
+     */
+    config?: Omit<MotionConfigProps, "children">
   }
 }
 

--- a/packages/providers/package.json
+++ b/packages/providers/package.json
@@ -47,6 +47,7 @@
     "@yamada-ui/core": "workspace:*",
     "@yamada-ui/utils": "workspace:*",
     "@yamada-ui/theme": "workspace:*",
+    "@yamada-ui/motion": "workspace:*",
     "@yamada-ui/loading": "workspace:*",
     "@yamada-ui/notice": "workspace:*"
   },

--- a/packages/providers/src/ui-provider.tsx
+++ b/packages/providers/src/ui-provider.tsx
@@ -10,6 +10,7 @@ import {
   GlobalStyle,
 } from "@yamada-ui/core"
 import { LoadingProvider } from "@yamada-ui/loading"
+import { MotionConfig } from "@yamada-ui/motion"
 import { NoticeProvider } from "@yamada-ui/notice"
 import { defaultTheme, defaultConfig } from "@yamada-ui/theme"
 import type { Dict } from "@yamada-ui/utils"
@@ -101,14 +102,16 @@ export const UIProvider: FC<UIProviderProps> = ({
           environment={environment}
           disabled={disableEnvironment}
         >
-          <LoadingProvider {...config.loading}>
-            {!disableResetStyle ? <ResetStyle /> : null}
-            {!disableGlobalStyle ? <GlobalStyle /> : null}
+          <MotionConfig {...config.motion?.config}>
+            <LoadingProvider {...config.loading}>
+              {!disableResetStyle ? <ResetStyle /> : null}
+              {!disableGlobalStyle ? <GlobalStyle /> : null}
 
-            {children}
+              {children}
 
-            <NoticeProvider {...config.notice} />
-          </LoadingProvider>
+              <NoticeProvider {...config.notice} />
+            </LoadingProvider>
+          </MotionConfig>
         </EnvironmentProvider>
       </ColorModeProvider>
     </ThemeProvider>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2510,6 +2510,9 @@ importers:
       '@yamada-ui/loading':
         specifier: workspace:*
         version: link:../components/loading
+      '@yamada-ui/motion':
+        specifier: workspace:*
+        version: link:../components/motion
       '@yamada-ui/notice':
         specifier: workspace:*
         version: link:../components/notice

--- a/stories/components/motion/utils.stories.tsx
+++ b/stories/components/motion/utils.stories.tsx
@@ -5,11 +5,12 @@ import {
   Button,
   Center,
   Motion,
-  MotionConfig,
   Text,
+  UIProvider,
   useBoolean,
   useScroll,
   useTransform,
+  extendConfig,
 } from "@yamada-ui/react"
 
 type Story = StoryFn<typeof Motion>
@@ -48,8 +49,12 @@ export const animatePresence: Story = () => {
 }
 
 export const motionConfig: Story = () => {
+  const config = extendConfig({
+    motion: { config: { transition: { duration: 2 } } },
+  })
+
   return (
-    <MotionConfig transition={{ duration: 2 }}>
+    <UIProvider config={config}>
       <Center w="calc(100vw - 16px * 2)" h="calc(100vh - 16px * 2)">
         <Motion
           animate={{ x: 100 }}
@@ -61,7 +66,7 @@ export const motionConfig: Story = () => {
           Motion
         </Motion>
       </Center>
-    </MotionConfig>
+    </UIProvider>
   )
 }
 


### PR DESCRIPTION
Closes #507

## Description

Include `MotionConfig` settings in `UIProvider` config.

## Current behavior (updates)

Currently, not support `framer-motion` config.

## New behavior

Added `framer-motion` config support.

## Is this a breaking change (Yes/No):

No