### PR TITLE
Fix/use-token/type

### DIFF
--- a/.changeset/gold-cows-remember.md
+++ b/.changeset/gold-cows-remember.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/use-token": patch
+---
+
+Excluded 'themeSchemes' from type.

--- a/.changeset/itchy-cherries-suffer.md
+++ b/.changeset/itchy-cherries-suffer.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Added `var` to Style props.

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -27,6 +27,7 @@ export type Transform = (value: any, theme: StyledTheme, css?: Dict) => any
 export type ConfigProps = {
   static?: CSSObject
   isProcessResult?: boolean
+  isProcessSkip?: boolean
   properties?:
     | CSSProperties
     | CSSProperties[]
@@ -264,6 +265,14 @@ export const keyframes = (...arg: CSSObject[]): Keyframes =>
 export type Transforms = keyof typeof transforms
 
 export const transforms = {
+  var: ({ name, token, value }: any, theme: StyledTheme) => {
+    const prefix = theme.__config.var?.prefix ?? "ui"
+
+    value = tokenToCSSVar(token, value)(theme)
+    name = `--${prefix}-${name}`
+
+    return { [name]: value }
+  },
   token:
     (
       token: ThemeToken,

--- a/packages/core/src/css/css.ts
+++ b/packages/core/src/css/css.ts
@@ -94,7 +94,7 @@ export const getCSS = ({
 
       if (style === true) style = { properties: key }
 
-      if (isObject(value)) {
+      if (isObject(value) && !style?.isProcessSkip) {
         resolvedCSS[key] = resolvedCSS[key] ?? {}
         resolvedCSS[key] = merge(resolvedCSS[key], createCSS(value, true))
 
@@ -103,9 +103,7 @@ export const getCSS = ({
 
       value = style?.transform?.(value, theme) ?? value
 
-      if (style?.isProcessResult) {
-        value = createCSS(value, true)
-      }
+      if (style?.isProcessResult) value = createCSS(value, true)
 
       if (!isNested && style?.static) {
         const staticStyles = runIfFunc(style.static, theme)

--- a/packages/core/src/styles.ts
+++ b/packages/core/src/styles.ts
@@ -3,6 +3,7 @@ import type * as CSS from "csstype"
 import type { Configs } from "./config"
 import { transforms } from "./config"
 import type { Token } from "./css"
+import type { Theme } from "./theme.types"
 
 export const standardStyles: Configs = {
   accentColor: {
@@ -1186,6 +1187,7 @@ export const standardStyles: Configs = {
     isSkip: true,
     transform: transforms.styles(),
   },
+  var: { isProcessSkip: true, isSkip: true, transform: transforms.var },
 }
 
 export const shorthandStyles: Configs = {
@@ -5140,4 +5142,17 @@ export type StyleProps = {
    * This will apply styles defined in `theme.styles.mdx.h1`
    */
   apply?: Token<StringLiteral>
+  /**
+   * Set CSS variables.
+   *
+   * @example
+   * ```jsx
+   * <Box var={[{ name:"space", token: "spaces", value: "md" }] m="calc(var(--ui-space) * 2)">Box</Box>
+   * ```
+   */
+  var?: {
+    name: string
+    token: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">
+    value: any
+  }[]
 }

--- a/packages/hooks/use-token/src/index.ts
+++ b/packages/hooks/use-token/src/index.ts
@@ -8,10 +8,10 @@ import {
 
 export const useToken = <
   Y extends string | number = string,
-  M extends keyof Omit<Theme, "components" | "colorSchemes"> = keyof Omit<
+  M extends keyof Omit<
     Theme,
-    "components" | "colorSchemes"
-  >,
+    "components" | "colorSchemes" | "themeSchemes"
+  > = keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">,
 >(
   name: M,
   path: Theme[M] | number | undefined,

--- a/scripts/generate-css/config.ts
+++ b/scripts/generate-css/config.ts
@@ -36,6 +36,7 @@ export const getConfig = ({
   transform,
   css,
   isProcessResult,
+  isProcessSkip,
   isSkip,
 }: {
   properties?:
@@ -45,6 +46,7 @@ export const getConfig = ({
   transform?: TransformOptions
   css?: CSSObject
   isProcessResult?: boolean
+  isProcessSkip?: boolean
   isSkip?: boolean
 }) => {
   if (!token && !transform && !css) return true
@@ -65,6 +67,7 @@ export const getConfig = ({
 
   if (token) config = [...config, `token: "${token}"`]
   if (isProcessResult) config = [...config, `isProcessResult: true`]
+  if (isProcessSkip) config = [...config, `isProcessSkip: true`]
   if (isSkip) config = [...config, `isSkip: true`]
   if (css) config = [...config, `static: ${JSON.stringify(css)}`]
   if (transform || token) config = insertTransform(config, token, transform)

--- a/scripts/generate-css/ui-props.ts
+++ b/scripts/generate-css/ui-props.ts
@@ -7,11 +7,13 @@ type UIProps = Partial<Record<string, UIOptions>>
 export type UIOptions = {
   static?: CSSObject
   isProcessResult?: boolean
+  isProcessSkip?: boolean
   properties?: Union<CSSProperties> | Union<CSSProperties>[]
   transform?: TransformOptions
   type?: string
   description?: string[]
   isSkip?: boolean
+  hasToken?: boolean
 }
 
 const createUIProps = <T extends UIProps>(props: T) => props
@@ -259,6 +261,21 @@ export const uiProps = createUIProps({
       "```",
       "",
       "This will apply styles defined in `theme.styles.mdx.h1`",
+    ],
+    isSkip: true,
+  },
+  var: {
+    isProcessSkip: true,
+    transform: "var",
+    type: '{ name: string; token: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">, value: any }[]',
+    hasToken: false,
+    description: [
+      "Set CSS variables.",
+      "",
+      "@example",
+      "```jsx",
+      '<Box var={[{ name:"space", token: "spaces", value: "md" }] m="calc(var(--ui-space) * 2)">Box</Box>',
+      "```",
     ],
     isSkip: true,
   },


### PR DESCRIPTION
Close #514
Close #513

## Description

`useToken` type is incorrect.

## Current behavior (updates)

`themeSchemes` is currently allowed in the type definition, but I can't get it.

## New behavior

Excluded 'themeSchemes' from type.

## Is this a breaking change (Yes/No):

No