### PR TITLE
feat(scripts): add prop validation in CSS generation

### DIFF
--- a/scripts/generate-css/check.ts
+++ b/scripts/generate-css/check.ts
@@ -1,0 +1,59 @@
+import { shorthandProps } from "./shorthand-props"
+import { tokens } from "./tokens"
+import { uiProps } from "./ui-props"
+import type { CSSProperty } from "."
+
+export const checkProps = (
+  styles: (CSSProperty & { type: string; deprecated: boolean })[],
+) => {
+  const propMap = styles.map(({ prop }) => prop) as string[]
+  const uiPropMap = Object.keys(uiProps) as string[]
+
+  Object.entries(tokens).reduce<string[]>((prev, [token, properties]) => {
+    properties.forEach((property) => {
+      if (prev.includes(property))
+        throw new Error(
+          `Duplicated prop in "token props", please check "${property}" in "${token}"`,
+        )
+    })
+
+    return [...prev, ...properties]
+  }, [])
+
+  Object.entries(shorthandProps).reduce<string[]>(
+    (prev, [relatedProperty, properties]) => {
+      properties.forEach((property) => {
+        if (prev.includes(property))
+          throw new Error(
+            `Duplicated prop in "shorthand props", please check "${property}" in "${relatedProperty}"`,
+          )
+      })
+
+      return [...prev, ...properties]
+    },
+    [],
+  )
+
+  Object.entries(shorthandProps).forEach(([relatedProperty, properties]) => {
+    properties.forEach((property) => {
+      if (propMap.includes(property))
+        throw new Error(
+          `Shorthand Prop already exists in "CSS Properties", please check "${property}" in "${relatedProperty}"`,
+        )
+    })
+  })
+
+  Object.entries(shorthandProps).forEach(([relatedProperty, properties]) => {
+    properties.forEach((property) => {
+      if (propMap.includes(property))
+        throw new Error(
+          `Shorthand Prop already exists in "CSS Properties", please check "${property}" in "${relatedProperty}"`,
+        )
+
+      if (uiPropMap.includes(property))
+        throw new Error(
+          `Shorthand Prop already exists in "UI Props", please check "${property}" in "${relatedProperty}"`,
+        )
+    })
+  })
+}

--- a/scripts/generate-css/layout-props.ts
+++ b/scripts/generate-css/layout-props.ts
@@ -1,3 +1,9 @@
+/**
+ * This is a temporary definition because it is used in each component.
+ * In the future, We would like to automate this.
+ *
+ * @deprecated
+ */
 export const layoutProps: string[] = [
   "width",
   "inlineSize",

--- a/scripts/generate-css/styles.ts
+++ b/scripts/generate-css/styles.ts
@@ -1,6 +1,7 @@
 import { writeFile } from "fs/promises"
 import type { ThemeToken } from "@yamada-ui/react"
 import { prettier, toKebabCase } from "../utils"
+import { checkProps } from "./check"
 import { getConfig } from "./config"
 import { layoutStyleProperties } from "./layout-props"
 import { resolveTypes } from "./resolve-types"
@@ -121,6 +122,8 @@ export const generateStyles = async (
   let shorthandStyles: string[] = []
   let styleProps: string[] = []
   let pickedStyles: (CSSProperty & { type: string })[] = []
+
+  checkProps(styles)
 
   styles = styles.filter((style) => {
     const isExists = Object.keys(uiProps).includes(style.prop)


### PR DESCRIPTION
Closes #521

## Description

Added validation in generating CSS properties

## Current behavior (updates)

Currently, we are automatically generating CSS properties, but we are not checking for shorthand duplicates.

## New behavior

Added validation in generating CSS properties

## Is this a breaking change (Yes/No):

No