### PR TITLE
Allow `breakpoints` to be selected up and down

### DIFF
--- a/.changeset/itchy-bulldogs-approve.md
+++ b/.changeset/itchy-bulldogs-approve.md
@@ -1,0 +1,6 @@
+---
+"@yamada-ui/use-breakpoint": minor
+"@yamada-ui/core": minor
+---
+
+Compatible with mobile-first responsive design.

--- a/.changeset/perfect-needles-sin.md
+++ b/.changeset/perfect-needles-sin.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": minor
+---
+
+Added `breakpoint` to config.

--- a/packages/core/src/components/use-component-style.tsx
+++ b/packages/core/src/components/use-component-style.tsx
@@ -252,8 +252,6 @@ const setStyles = <Props extends Dict = Dict, IsMulti extends boolean = false>(
       { theme, colorMode, themeScheme, ...args },
     )({ isMulti })
 
-    // console.log(variantStyles)
-
     styles = merge(styles, sizeStyles)
     styles = merge(styles, variantStyles)
 

--- a/packages/core/src/components/use-component-style.tsx
+++ b/packages/core/src/components/use-component-style.tsx
@@ -11,7 +11,9 @@ import {
 } from "@yamada-ui/utils"
 import { useRef } from "react"
 import isEqual from "react-fast-compare"
+import { createQuery } from "../css"
 import type {
+  BreakpointQueries,
   CSSUIObject,
   ColorModeArray,
   ResponsiveObject,
@@ -32,93 +34,153 @@ type Styles<isMulti extends boolean = false> = isMulti extends false
   ? CSSUIObject
   : Record<string, CSSUIObject>
 
+type ModifierStyles =
+  | ComponentVariants
+  | ComponentSizes
+  | ComponentMultiVariants
+  | ComponentMultiSizes
+
+type GetStylesOptions = { isMulti: boolean; query?: string }
+
+const getColorModeStyles =
+  <IsMulti extends boolean = false>(
+    value: ColorModeArray<string>,
+    modifierStyles: ModifierStyles,
+    props: UIStyleProps,
+  ) =>
+  ({ isMulti }: GetStylesOptions) => {
+    const [lightValue, darkValue] = value
+
+    const lightStyles = getStyles<IsMulti>(
+      modifierStyles[lightValue],
+      props,
+    )({ isMulti, query: pseudos._light })
+
+    const darkStyles = getStyles<IsMulti>(
+      modifierStyles[darkValue],
+      props,
+    )({ isMulti, query: pseudos._dark })
+
+    return [lightStyles, darkStyles]
+  }
+
+const getResponsiveStyles =
+  <IsMulti extends boolean = false>(
+    value: ResponsiveObject<string>,
+    modifierStyles: ModifierStyles,
+    props: UIStyleProps,
+  ) =>
+  ({ isMulti }: GetStylesOptions) => {
+    const providedKeys = keysFormObject(value)
+
+    if (providedKeys.length === 1 && "base" in value) {
+      return getStyles<IsMulti>(modifierStyles[value.base], props)({ isMulti })
+    } else {
+      const { queries = [] } = props.theme.__breakpoints ?? {}
+      const { breakpoint } = props.theme.__config ?? {}
+      const isDown = breakpoint === "down"
+
+      const finalQuery = queries
+        .filter(
+          ({ breakpoint }) =>
+            breakpoint !== "base" && providedKeys.includes(breakpoint),
+        )
+        .sort((a, b) =>
+          isDown
+            ? (a.maxW ?? 0) - (b.maxW ?? 0)
+            : (b.minW ?? 0) - (a.minW ?? 0),
+        )[0]
+
+      let hasBaseStyles = false
+
+      return queries.reduce<Styles<IsMulti>>(
+        (prev, { breakpoint, minW, maxW, maxWQuery, minWQuery }, index) => {
+          const modifier = value[breakpoint]
+          const isFinal = breakpoint === finalQuery.breakpoint
+
+          if (breakpoint === "base") return prev
+          if (!modifier) return prev
+
+          if (!hasBaseStyles) {
+            const baseModifier = value["base"]
+            const prevQuery = queries[index - 1]
+            const query = prevQuery?.[isDown ? "minWQuery" : "maxWQuery"]
+
+            const baseStyles = getStyles<IsMulti>(
+              modifierStyles[baseModifier],
+              props,
+            )({ isMulti, query })
+
+            prev = merge(prev, baseStyles)
+
+            hasBaseStyles = true
+          }
+
+          let query = isDown ? maxWQuery : minWQuery
+
+          if (!isFinal) {
+            let nextIndex = index + 1
+            let nextQuery: BreakpointQueries[number] | undefined
+
+            while (nextIndex < queries.length) {
+              const query = queries[nextIndex] ?? {}
+
+              if (value[query.breakpoint]) {
+                const targetIndex = nextIndex - 1
+
+                nextQuery = queries[targetIndex]
+
+                break
+              }
+
+              nextIndex += 1
+            }
+
+            minW = isDown ? nextQuery?.minW : minW
+            maxW = isDown ? maxW : nextQuery?.maxW
+
+            query = createQuery(minW, maxW)
+          }
+
+          const queryStyles = getStyles<IsMulti>(
+            modifierStyles[modifier],
+            props,
+          )({ isMulti, query })
+
+          prev = merge(prev, queryStyles)
+
+          return prev
+        },
+        {},
+      )
+    }
+  }
+
 const getModifierStyles =
   <IsMulti extends boolean = false>(
     value: ResponsiveObject<string> | ColorModeArray<string> | string,
-    singleOrMultiStyles:
-      | ComponentVariants
-      | ComponentSizes
-      | ComponentMultiVariants
-      | ComponentMultiSizes,
+    modifierStyles: ModifierStyles,
     props: UIStyleProps,
   ) =>
-  ({ isMulti }: { isMulti: boolean }): Styles<IsMulti> => {
+  ({ isMulti }: GetStylesOptions): Styles<IsMulti> => {
     let styles: Styles<IsMulti> = {}
 
     if (isArray(value)) {
-      const [lightValue, darkValue] = value
-
-      const lightStyles = getStyles<IsMulti>(
-        singleOrMultiStyles[lightValue],
+      const [lightStyles, darkStyles] = getColorModeStyles<IsMulti>(
+        value,
+        modifierStyles,
         props,
-      )({ isMulti, query: pseudos._light })
-
-      const darkStyles = getStyles<IsMulti>(
-        singleOrMultiStyles[darkValue],
-        props,
-      )({ isMulti, query: pseudos._dark })
+      )({ isMulti })
 
       styles = merge(lightStyles, darkStyles)
     } else if (isObject(value)) {
-      if (keysFormObject(value).length === 1 && "base" in value) {
-        styles = getStyles<IsMulti>(
-          singleOrMultiStyles[value.base],
-          props,
-        )({ isMulti })
-      } else {
-        const { queries = [] } = props.theme.__breakpoints ?? {}
-
-        const omitQueries = queries.filter(
-          ({ breakpoint }) =>
-            breakpoint !== "base" && keysFormObject(value).includes(breakpoint),
-        )
-
-        const minQuery = omitQueries.sort(
-          (a, b) => (a.minW ?? 0) - (b.minW ?? 0),
-        )[0]
-        const maxQuery = omitQueries.sort(
-          (a, b) => (b.minW ?? 0) - (a.minW ?? 0),
-        )[0]
-        const nextMaxQuery = queries
-          .filter(({ minW }) => (minW ?? 0) > (maxQuery?.minW ?? 0))
-          .sort((a, b) => (a.minW ?? 0) - (b.minW ?? 0))[0]
-
-        styles = Object.entries(value).reduce(
-          (styles, [breakpointKey, breakpointValue = ""]) => {
-            if (breakpointKey === "base") {
-              const query = nextMaxQuery.minWQuery
-
-              const baseStyles = getStyles<IsMulti>(
-                singleOrMultiStyles[breakpointValue],
-                props,
-              )({ isMulti, query })
-
-              styles = merge(styles, baseStyles)
-            } else {
-              const isMin = breakpointKey === minQuery.breakpoint
-
-              const query = queries?.find(
-                ({ breakpoint }) => breakpoint === breakpointKey,
-              )?.[isMin ? "maxWQuery" : "minMaxQuery"]
-
-              const queryStyles = getStyles<IsMulti>(
-                singleOrMultiStyles[breakpointValue],
-                props,
-              )({ isMulti, query })
-
-              styles = merge(styles, queryStyles)
-            }
-
-            return styles
-          },
-          {} as Styles<IsMulti>,
-        )
-      }
-    } else {
-      styles = getStyles<IsMulti>(
-        singleOrMultiStyles[value],
+      styles = getResponsiveStyles<IsMulti>(
+        value,
+        modifierStyles,
         props,
       )({ isMulti })
+    } else {
+      styles = getStyles<IsMulti>(modifierStyles[value], props)({ isMulti })
     }
 
     return styles as Styles<IsMulti>
@@ -129,13 +191,7 @@ const getStyles =
     stylesOrFunc: UIStyle | Record<string, UIStyle>,
     props: UIStyleProps,
   ) =>
-  ({
-    isMulti,
-    query,
-  }: {
-    isMulti: boolean
-    query?: string
-  }): Styles<IsMulti> => {
+  ({ isMulti, query }: GetStylesOptions): Styles<IsMulti> => {
     let styles = runIfFunc(stylesOrFunc, props)
 
     if (isMulti) {
@@ -195,6 +251,8 @@ const setStyles = <Props extends Dict = Dict, IsMulti extends boolean = false>(
       componentStyle.sizes ?? {},
       { theme, colorMode, themeScheme, ...args },
     )({ isMulti })
+
+    // console.log(variantStyles)
 
     styles = merge(styles, sizeStyles)
     styles = merge(styles, variantStyles)

--- a/packages/core/src/css/css.ts
+++ b/packages/core/src/css/css.ts
@@ -19,14 +19,13 @@ const expandResponsive = (
   value: Dict,
   queries: BreakpointQueries,
 ): Dict =>
-  [...queries].reverse().reduce((prev, { breakpoint, maxWQuery }) => {
-    if (breakpoint === "base") {
-      prev[key] = value[breakpoint]
-    } else {
-      const breakpointValue = value[breakpoint]
+  queries.reduce((prev, { breakpoint, query }) => {
+    const breakpointValue = value[breakpoint]
 
-      if (breakpointValue && maxWQuery)
-        prev[maxWQuery] = { [key]: breakpointValue }
+    if (query) {
+      prev[query] = { [key]: breakpointValue }
+    } else {
+      prev[key] = value[breakpoint]
     }
 
     return prev

--- a/packages/core/src/theme.ts
+++ b/packages/core/src/theme.ts
@@ -97,7 +97,7 @@ export const transformTheme = (theme: Dict, config?: ThemeConfig): Dict => {
     __config: config,
     __cssVars: { ...defaultCSSVars, ...cssVars },
     __cssMap: cssMap,
-    __breakpoints: analyzeBreakpoints(breakpoints),
+    __breakpoints: analyzeBreakpoints(breakpoints, config?.breakpoint),
   })
 
   return theme

--- a/packages/core/src/theme.types.ts
+++ b/packages/core/src/theme.types.ts
@@ -14,6 +14,8 @@ import type {
 import type { GeneratedTheme } from "./generated-theme.types"
 import type { UITheme } from "./ui-theme.types"
 
+export type BreakpointDirection = "up" | "down"
+
 export type LoadingVariant =
   | "oval"
   | "grid"
@@ -226,6 +228,11 @@ export type ThemeConfig = {
    * @default false
    */
   disableTransitionOnChange?: boolean
+  /**
+   *
+   * @default "down"
+   */
+  breakpoint?: BreakpointDirection
   /**
    * The config of the calendar or date picker etc.
    */

--- a/packages/core/src/theme.types.ts
+++ b/packages/core/src/theme.types.ts
@@ -229,6 +229,10 @@ export type ThemeConfig = {
    */
   disableTransitionOnChange?: boolean
   /**
+   * The `breakpoint` direction controls the responsive design approach.
+   *
+   * - `down`: desktop-first using `max-width`.
+   * - `up`: mobile-first using `min-width`.
    *
    * @default "down"
    */

--- a/packages/hooks/use-breakpoint/src/index.ts
+++ b/packages/hooks/use-breakpoint/src/index.ts
@@ -97,7 +97,7 @@ export const useBreakpointValue = <T extends any>(
 
   const currentIndex = breakpoints.indexOf(breakpoint)
 
-  for (let i = currentIndex; i < breakpoints.length; i++) {
+  for (let i = currentIndex; 0 < i; i--) {
     const nextBreakpoint = breakpoints[i]
 
     if (values.hasOwnProperty(nextBreakpoint)) {

--- a/packages/theme/src/config.ts
+++ b/packages/theme/src/config.ts
@@ -4,4 +4,5 @@ export const config: ThemeConfig = {
   initialThemeScheme: "base",
   initialColorMode: "light",
   var: { prefix: "ui" },
+  breakpoint: "down",
 }


### PR DESCRIPTION
Closes #166

## Description

Allow `breakpoint` settings to be defined in the `config`.

> Add a brief description

## Current behavior (updates)

Currently, Yamada UI's responsive design has a breakpoint set at max-width. Depending on the project you should be able to choose the min-width.

## New behavior

Added `breakpoint` to config.

## Is this a breaking change (Yes/No):

No