### PR TITLE
Fix `colorScheme` type

### DIFF
--- a/.changeset/smart-bulldogs-joke.md
+++ b/.changeset/smart-bulldogs-joke.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Added `colorMode` property.

--- a/packages/core/src/styles.ts
+++ b/packages/core/src/styles.ts
@@ -334,7 +334,6 @@ export const standardStyles: Configs = {
     token: "colors",
     transform: transforms.token("colors"),
   },
-  colorScheme: true,
   columnCount: true,
   columnFill: true,
   columnGap: {
@@ -1069,8 +1068,8 @@ export const standardStyles: Configs = {
     token: "sizes",
     transform: transforms.token("sizes", transforms.fraction(transforms.px)),
   },
-  minBoxSize: true,
-  maxBoxSize: true,
+  minBoxSize: { properties: ["minWidth", "minHeight"] },
+  maxBoxSize: { properties: ["maxWidth", "maxHeight"] },
   translateX: {
     properties: "--ui-translate-x",
     token: "spaces",
@@ -1081,9 +1080,9 @@ export const standardStyles: Configs = {
     token: "spaces",
     transform: transforms.token("spaces", transforms.px),
   },
-  scale: true,
-  scaleX: true,
-  scaleY: true,
+  scale: { properties: ["--ui-scale-x", "--ui-scale-y"] },
+  scaleX: { properties: "--ui-scale-x" },
+  scaleY: { properties: "--ui-scale-y" },
   rotate: { properties: "--ui-rotate", transform: transforms.deg },
   skewX: { properties: "--ui-skew-x", transform: transforms.deg },
   skewY: { properties: "--ui-skew-y", transform: transforms.deg },
@@ -1190,6 +1189,7 @@ export const standardStyles: Configs = {
     transform: transforms.styles(),
   },
   var: { isProcessSkip: true, isSkip: true, transform: transforms.var },
+  colorMode: { properties: "colorScheme" },
 }
 
 export const shorthandStyles: Configs = {
@@ -2459,12 +2459,6 @@ export type StyleProps = {
    * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/color
    */
   textColor?: Token<CSS.Property.Color, "colors">
-  /**
-   * The CSS `color-scheme` property.
-   *
-   * @see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme
-   */
-  colorScheme?: Token<CSS.Property.ColorScheme>
   /**
    * The CSS `column-count` property.
    *
@@ -5248,4 +5242,8 @@ export type StyleProps = {
     token: keyof Omit<Theme, "components" | "colorSchemes" | "themeSchemes">
     value: Token<StringLiteral | number>
   }[]
+  /**
+   * The CSS `colorScheme` property.
+   */
+  colorMode?: Token<CSS.Property.ColorScheme>
 }

--- a/scripts/generate-css/config.ts
+++ b/scripts/generate-css/config.ts
@@ -30,47 +30,49 @@ const insertTransform = (
   return config
 }
 
-export const getConfig = ({
-  properties,
-  token,
-  transform,
-  css,
-  isProcessResult,
-  isProcessSkip,
-  isSkip,
-}: {
-  properties?:
-    | Union<CSSProperties | UIProperties>
-    | Union<CSSProperties | UIProperties>[]
-  token?: ThemeToken
-  transform?: TransformOptions
-  css?: CSSObject
-  isProcessResult?: boolean
-  isProcessSkip?: boolean
-  isSkip?: boolean
-}) => {
-  if (!token && !transform && !css) return true
+export const getConfig =
+  ({
+    properties,
+    token,
+    transform,
+    css,
+    isProcessResult,
+    isProcessSkip,
+    isSkip,
+  }: {
+    properties?:
+      | Union<CSSProperties | UIProperties>
+      | Union<CSSProperties | UIProperties>[]
+    token?: ThemeToken
+    transform?: TransformOptions
+    css?: CSSObject
+    isProcessResult?: boolean
+    isProcessSkip?: boolean
+    isSkip?: boolean
+  }) =>
+  (isConfig?: boolean) => {
+    if (!isConfig && !token && !transform && !css) return true
 
-  let config: string[] = []
+    let config: string[] = []
 
-  if (properties) {
-    if (typeof properties === "string") {
-      const value = `"${properties}"`
+    if (properties) {
+      if (typeof properties === "string") {
+        const value = `"${properties}"`
 
-      config = [...config, `properties: ${value}`]
-    } else {
-      const value = `[${properties.map((p) => `"${p}"`).join(", ")}]`
+        config = [...config, `properties: ${value}`]
+      } else {
+        const value = `[${properties.map((p) => `"${p}"`).join(", ")}]`
 
-      config = [...config, `properties: ${value}`]
+        config = [...config, `properties: ${value}`]
+      }
     }
+
+    if (token) config = [...config, `token: "${token}"`]
+    if (isProcessResult) config = [...config, `isProcessResult: true`]
+    if (isProcessSkip) config = [...config, `isProcessSkip: true`]
+    if (isSkip) config = [...config, `isSkip: true`]
+    if (css) config = [...config, `static: ${JSON.stringify(css)}`]
+    if (transform || token) config = insertTransform(config, token, transform)
+
+    return `{ ${config.join(", ")} }`
   }
-
-  if (token) config = [...config, `token: "${token}"`]
-  if (isProcessResult) config = [...config, `isProcessResult: true`]
-  if (isProcessSkip) config = [...config, `isProcessSkip: true`]
-  if (isSkip) config = [...config, `isSkip: true`]
-  if (css) config = [...config, `static: ${JSON.stringify(css)}`]
-  if (transform || token) config = insertTransform(config, token, transform)
-
-  return `{ ${config.join(", ")} }`
-}

--- a/scripts/generate-css/exclude-props.ts
+++ b/scripts/generate-css/exclude-props.ts
@@ -1,3 +1,3 @@
 import type { CSSProperties } from "."
 
-export const excludeProps: CSSProperties[] = ["transition"]
+export const excludeProps: CSSProperties[] = ["transition", "colorScheme"]

--- a/scripts/generate-css/styles.ts
+++ b/scripts/generate-css/styles.ts
@@ -137,7 +137,7 @@ export const generateStyles = async (
     const token: ThemeToken | undefined = tokenMap[prop]
     const shorthands = shorthandProps[prop]
     const transform = transformMap[prop]
-    const config = getConfig({ properties: prop, token, transform })
+    const config = getConfig({ properties: prop, token, transform })()
     type = computedType({ type, token, transform, prop })
     const docs = generateDocs({ properties: name, urls: [url], deprecated })
 
@@ -193,7 +193,7 @@ export const generateStyles = async (
         isProcessSkip,
         isSkip,
         css,
-      })
+      })(true)
       type = computedType({ type: type ?? types, hasToken, token, transform })
       const docs = generateDocs({ properties, description, urls, deprecated })
 

--- a/scripts/generate-css/ui-props.ts
+++ b/scripts/generate-css/ui-props.ts
@@ -103,7 +103,11 @@ export const uiProps = createUIProps({
   filter: {
     transform: { transform: "filter" },
     type: `CSS.Property.Filter | "auto"`,
-    description: ["The CSS `filter` property."],
+    description: [
+      "The CSS `filter` property.",
+      "",
+      "@see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/filter",
+    ],
   },
   blur: {
     properties: "--ui-blur",
@@ -153,7 +157,11 @@ export const uiProps = createUIProps({
   backdropFilter: {
     transform: { transform: "filter", args: `"backdrop"` },
     type: `CSS.Property.BackdropFilter | "auto"`,
-    description: ["The CSS `backdrop-filter` property."],
+    description: [
+      "The CSS `backdrop-filter` property.",
+      "",
+      "@see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/backdrop-filter",
+    ],
   },
   backdropBlur: {
     properties: "--ui-backdrop-blur",
@@ -280,5 +288,14 @@ export const uiProps = createUIProps({
       "```",
     ],
     isSkip: true,
+  },
+  colorMode: {
+    properties: "colorScheme",
+    type: "CSS.Property.ColorScheme",
+    description: [
+      "The CSS `color-scheme` property.",
+      "",
+      "@see Docs https://developer.mozilla.org/en-US/docs/Web/CSS/color-scheme",
+    ],
   },
 })


### PR DESCRIPTION
Closes #534

## Description

`colorScheme` type is incorrect

## Current behavior (updates)

The type is an intersection type because the Yamada UI `colorScheme` and the CSS property `colorScheme` have duplicate names.

## New behavior

Added `colorMode` property.

## Is this a breaking change (Yes/No):

No