### PR TITLE
Adjusted `SegmantedControl` component `zIndex`

### DIFF
--- a/.changeset/four-lobsters-help.md
+++ b/.changeset/four-lobsters-help.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Updated `SegmentedControl` styles.

--- a/.changeset/twenty-olives-brake.md
+++ b/.changeset/twenty-olives-brake.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/segmented-control": patch
+---
+
+Adjusted cursor element `zIndex`.

--- a/packages/components/segmented-control/src/segmented-control.tsx
+++ b/packages/components/segmented-control/src/segmented-control.tsx
@@ -262,7 +262,6 @@ export const SegmentedControl = forwardRef<SegmentedControlProps, "div">(
     }, [])
 
     const css: CSSUIObject = {
-      position: "relative",
       display: "inline-flex",
       alignItems: "center",
       ...styles.container,
@@ -397,10 +396,10 @@ export const SegmentedControlButton = forwardRef<
         {...rest}
       >
         <ui.input {...getInputProps(props, mergeRefs(register, ref))} />
-        <ui.span>{children}</ui.span>
         {isSelected && isMounted ? (
           <SegmentedControlCursor {...motionProps} />
         ) : null}
+        <ui.span zIndex="1">{children}</ui.span>
       </ui.label>
     )
   },
@@ -419,7 +418,6 @@ const SegmentedControlCursor: FC<SegmentedControlCursorProps> = ({
 
   const css: CSSUIObject = {
     position: "absolute",
-    zIndex: "-10",
     w: "full",
     h: "full",
     ...styles.cursor,

--- a/packages/theme/src/components/segmented-control.ts
+++ b/packages/theme/src/components/segmented-control.ts
@@ -5,12 +5,12 @@ export const SegmentedControl: ComponentMultiStyle = {
   baseStyle: {
     container: {
       p: "1",
-      bg: ["blackAlpha.50", "whiteAlpha.50"],
+      bg: ["blackAlpha.100", "whiteAlpha.50"],
       _readOnly: { cursor: "auto" },
       _disabled: { cursor: "not-allowed" },
     },
     cursor: {
-      boxShadow: "md",
+      boxShadow: ["md", "dark-md"],
     },
     button: {
       transitionProperty: "common",
@@ -39,7 +39,7 @@ export const SegmentedControl: ComponentMultiStyle = {
       },
       cursor: {
         bg: isGray(c)
-          ? [`whiteAlpha.700`, `${c}.700`]
+          ? [`whiteAlpha.800`, `${c}.700`]
           : [isAccessible(c) ? `${c}.400` : `${c}.500`, `${c}.600`],
         color: [isGray(c) || isAccessible(c) ? `black` : `white`, `white`],
         rounded: "md",
@@ -57,7 +57,7 @@ export const SegmentedControl: ComponentMultiStyle = {
       },
       cursor: {
         bg: isGray(c)
-          ? [`whiteAlpha.700`, `${c}.700`]
+          ? [`whiteAlpha.800`, `${c}.700`]
           : [isAccessible(c) ? `${c}.400` : `${c}.500`, `${c}.600`],
         color: [isGray(c) || isAccessible(c) ? `black` : `white`, `white`],
         rounded: "full",


### PR DESCRIPTION
Closes #558

## Description

cursor element of `SegmentedControl` is hidden

## Current behavior (updates)

When setting a `background` to the container element of `SegmentedControl`, the cursor element is hidden. This is a problem with the `z-index` of the cursor element.

## New behavior

Added `zIndex` to label element.
Update `zIndex` of cursor element.

## Is this a breaking change (Yes/No):

No