### PR TITLE
Fixed `aria-readonly` of `Rating`

### DIFF
--- a/.changeset/cool-kangaroos-hope.md
+++ b/.changeset/cool-kangaroos-hope.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/rating": patch
+---
+
+Removed unnecessary `aria-readonly`.

--- a/packages/components/rating/src/use-rating.tsx
+++ b/packages/components/rating/src/use-rating.tsx
@@ -6,7 +6,7 @@ import type {
 } from "@yamada-ui/core"
 import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
-  formControlProperties,
+  getFormControlProperties,
   useFormControlProps,
 } from "@yamada-ui/form-control"
 import type { RequiredMotionUIPropGetter } from "@yamada-ui/motion"
@@ -20,6 +20,7 @@ import {
   handlerAll,
   mergeRefs,
   pickObject,
+  omitObject,
   runIfFunc,
 } from "@yamada-ui/utils"
 import type {
@@ -195,7 +196,10 @@ export const useRating = ({
   id ??= useId()
   name ??= `rating-${id}`
 
-  const formControlProps = pickObject(rest, formControlProperties)
+  const formControlProps = pickObject(
+    rest,
+    getFormControlProperties({ omit: ["aria-readonly"] }),
+  )
   const resolvedFractions = Math.floor(fractions)
   const resolvedItems = Math.floor(items)
   const decimal = 1 / resolvedFractions
@@ -268,7 +272,7 @@ export const useRating = ({
   const getContainerProps: UIPropGetter = useCallback(
     (props = {}, ref = null) => ({
       ref: mergeRefs(ref, containerRef),
-      ...rest,
+      ...omitObject(rest, ["aria-readonly"]),
       ...props,
       id,
       onMouseEnter: handlerAll(


### PR DESCRIPTION
Closes #573

## Description

`Rating` must only use allowed ARIA attributes

## Current behavior (updates)

When setting `isReadonly` to `Rating` components, `aria-readonly` is assigned to unnecessary elements.

## New behavior

Removed unnecessary `aria-readonly`.

## Is this a breaking change (Yes/No):

No