### PR TITLE
Fixed element type for Card component

### DIFF
--- a/.changeset/cool-parrots-exercise.md
+++ b/.changeset/cool-parrots-exercise.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/card": patch
+---
+
+Fixed a bug where the Card component was rendering a div element instead of a section element.

--- a/packages/components/card/src/card.tsx
+++ b/packages/components/card/src/card.tsx
@@ -57,7 +57,7 @@ export const Card = forwardRef<CardProps, "article">((props, ref) => {
 
   return (
     <CardProvider value={styles}>
-      <ui.div
+      <ui.section
         ref={ref}
         className={cx("ui-card", className)}
         __css={css}


### PR DESCRIPTION
Closes #577

## Description

The rendered element of the `Card` component is incorrect.

## Current behavior (updates)

The documentation explains that the `section` element is rendered in the `Cart` component, but in reality, the `div` element is rendered.

## New behavior

Fixed element type for Card component.

## Is this a breaking change (Yes/No):

No