### PR TITLE
Fixed a bug where `Prettier` config was not being referenced.

### DIFF
--- a/.changeset/real-zebras-smash.md
+++ b/.changeset/real-zebras-smash.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/cli": patch
+---
+
+Fixed a bug where `Prettier` config was not being referenced.

--- a/.changeset/rotten-paws-perform.md
+++ b/.changeset/rotten-paws-perform.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/core": patch
+---
+
+Formatted `generated-theme.types.ts` file.

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -51,7 +51,7 @@
     "color2k": "^2.0.3",
     "commander": "^11.1.0",
     "glob": "^10.3.10",
-    "prettier": "^3.1.0"
+    "prettier": "^3.1.1"
   },
   "devDependencies": {
     "@types/cli-welcome": "^2.2.2",

--- a/packages/cli/src/utils/prettier.ts
+++ b/packages/cli/src/utils/prettier.ts
@@ -1,8 +1,11 @@
+import path from "path"
 import type { Options } from "prettier"
 import { format, resolveConfig } from "prettier"
 
 export const prettier = async (content: string, options?: Options) => {
-  const prettierConfig = await resolveConfig(process.cwd())
+  const prettierConfig = await resolveConfig(
+    path.join(process.cwd(), ".prettierrc"),
+  )
 
   try {
     return format(content, {

--- a/packages/core/src/generated-theme.types.ts
+++ b/packages/core/src/generated-theme.types.ts
@@ -842,10 +842,7 @@ export interface GeneratedTheme extends UITheme {
       sizes: "sm" | "md" | "lg" | "xl" | (string & {})
       variants: "simple" | "striped" | "unstyled" | (string & {})
     }
-    Slider: {
-      sizes: "sm" | "md" | "lg" | (string & {})
-      variants: string & {}
-    }
+    Slider: { sizes: "sm" | "md" | "lg" | (string & {}); variants: string & {} }
     Stepper: {
       sizes: "sm" | "md" | "lg" | (string & {})
       variants: string & {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -517,8 +517,8 @@ importers:
         specifier: ^10.3.10
         version: registry.npmjs.org/glob@10.3.10
       prettier:
-        specifier: ^3.1.0
-        version: registry.npmjs.org/prettier@3.1.1
+        specifier: ^3.1.1
+        version: 3.1.1
     devDependencies:
       '@types/cli-welcome':
         specifier: ^2.2.2
@@ -4348,7 +4348,7 @@ packages:
     resolution: {integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz}
     engines: {node: '>=4'}
     dependencies:
-      color-convert: 1.9.3
+      color-convert: registry.npmjs.org/color-convert@1.9.3
 
   /ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==, tarball: https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz}
@@ -4434,19 +4434,11 @@ packages:
       supports-color: 7.2.0
     dev: false
 
-  /color-convert@1.9.3:
-    resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==, tarball: https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz}
-    dependencies:
-      color-name: 1.1.3
-
   /color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==, tarball: https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz}
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-
-  /color-name@1.1.3:
-    resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz}
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==, tarball: https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz}
@@ -4955,6 +4947,18 @@ packages:
       nanoid: 3.3.7
       picocolors: 1.0.0
       source-map-js: 1.0.2
+
+  /prettier@2.8.8:
+    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==, tarball: https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    dev: false
+
+  /prettier@3.1.1:
+    resolution: {integrity: sha512-22UbSzg8luF4UuZtzgiUOfcGM8s4tjBv6dJRT7j275NXsy2jb4aJa4NNveul5x4eqlF1wuhuR2RElK71RvmVaw==, tarball: https://registry.npmjs.org/prettier/-/prettier-3.1.1.tgz}
+    engines: {node: '>=14'}
+    hasBin: true
+    dev: false
 
   /pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==, tarball: https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz}
@@ -7061,7 +7065,7 @@ packages:
       fs-extra: registry.npmjs.org/fs-extra@7.0.1
       lodash.startcase: registry.npmjs.org/lodash.startcase@4.4.0
       outdent: registry.npmjs.org/outdent@0.5.0
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
       resolve-from: registry.npmjs.org/resolve-from@5.0.0
       semver: registry.npmjs.org/semver@7.5.4
     dev: false
@@ -7283,7 +7287,7 @@ packages:
       '@changesets/types': registry.npmjs.org/@changesets/types@6.0.0
       fs-extra: registry.npmjs.org/fs-extra@7.0.1
       human-id: registry.npmjs.org/human-id@1.0.2
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
     dev: false
 
   registry.npmjs.org/@clack/core@0.3.3:
@@ -10146,7 +10150,7 @@ packages:
       jscodeshift: registry.npmjs.org/jscodeshift@0.15.1(@babel/preset-env@7.23.6)
       leven: registry.npmjs.org/leven@3.1.0
       ora: registry.npmjs.org/ora@5.4.1
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
       prompts: registry.npmjs.org/prompts@2.4.2
       puppeteer-core: registry.npmjs.org/puppeteer-core@2.1.1
       read-pkg-up: registry.npmjs.org/read-pkg-up@7.0.1
@@ -10188,7 +10192,7 @@ packages:
       globby: registry.npmjs.org/globby@11.1.0
       jscodeshift: registry.npmjs.org/jscodeshift@0.15.1(@babel/preset-env@7.23.6)
       lodash: registry.npmjs.org/lodash@4.17.21
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
       recast: registry.npmjs.org/recast@0.23.4
     transitivePeerDependencies:
       - supports-color
@@ -10571,7 +10575,7 @@ packages:
       '@storybook/types': registry.npmjs.org/@storybook/types@7.6.6
       estraverse: registry.npmjs.org/estraverse@5.3.0
       lodash: registry.npmjs.org/lodash@4.17.21
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
     dev: false
 
   registry.npmjs.org/@storybook/telemetry@7.6.6:
@@ -13815,7 +13819,7 @@ packages:
     dependencies:
       chalk: registry.npmjs.org/chalk@2.4.2
       clear-any-console: registry.npmjs.org/clear-any-console@1.16.2
-      prettier: registry.npmjs.org/prettier@2.8.8
+      prettier: 2.8.8
     dev: false
 
   registry.npmjs.org/cli-width@4.1.0:
@@ -23922,14 +23926,6 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       fast-diff: registry.npmjs.org/fast-diff@1.3.0
-    dev: false
-
-  registry.npmjs.org/prettier@2.8.8:
-    resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==, registry: https://registry.npmjs.com/, tarball: https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz}
-    name: prettier
-    version: 2.8.8
-    engines: {node: '>=10.13.0'}
-    hasBin: true
     dev: false
 
   registry.npmjs.org/prettier@3.1.1:


### PR DESCRIPTION
Closes #579

## Description

`Prettier` config is not referenced.

## Current behavior (updates)

The config reference logic has changed since `Prettier` version 3.1.0, so it is always null.

## New behavior

Fixed a bug where `Prettier` config was not being referenced.

## Is this a breaking change (Yes/No):

No