### PR TITLE
Fixed `aria-readonly` of `Slider` and `RangeSlider`

### DIFF
--- a/.changeset/hip-dodos-type.md
+++ b/.changeset/hip-dodos-type.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/slider": patch
+---
+
+Removed unnecessary `aria-readonly`.

--- a/packages/components/slider/src/range-slider.tsx
+++ b/packages/components/slider/src/range-slider.tsx
@@ -16,6 +16,7 @@ import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
   useFormControlProps,
   formControlProperties,
+  getFormControlProperties,
 } from "@yamada-ui/form-control"
 import { useControllableState } from "@yamada-ui/use-controllable-state"
 import { useLatestRef } from "@yamada-ui/use-latest-ref"
@@ -42,7 +43,7 @@ import {
   valueToPercent,
   includesChildren,
 } from "@yamada-ui/utils"
-import type { CSSProperties, KeyboardEvent } from "react"
+import type { CSSProperties, KeyboardEvent, KeyboardEventHandler } from "react"
 import { useCallback, useId, useRef, useState } from "react"
 
 export type UseRangeSliderProps = FormControlOptions & {
@@ -368,7 +369,7 @@ export const useRangeSlider = ({
       const { valueBounds } = latestRef.current
       const { min, max } = valueBounds[activeIndex]
 
-      const actions: Record<string, React.KeyboardEventHandler> = {
+      const actions: Record<string, KeyboardEventHandler> = {
         ArrowRight: () => stepUp(activeIndex),
         ArrowUp: () => stepUp(activeIndex),
         ArrowLeft: () => stepDown(activeIndex),
@@ -423,7 +424,12 @@ export const useRangeSlider = ({
       }
 
       return {
-        ...omitObject(rest, ["value", "onChangeStart", "onChangeEnd"]),
+        ...omitObject(rest, [
+          "aria-readonly",
+          "value",
+          "onChangeStart",
+          "onChangeEnd",
+        ]),
         ...props,
         id: `slider-container-${id}`,
         ref: mergeRefs(ref, containerRef),
@@ -470,7 +476,10 @@ export const useRangeSlider = ({
       }
 
       return {
-        ...pickObject(rest, formControlProperties),
+        ...pickObject(
+          rest,
+          getFormControlProperties({ omit: ["aria-readonly"] }),
+        ),
         ...props,
         id: `slider-track-${id}`,
         ref: mergeRefs(ref, trackRef),
@@ -504,7 +513,10 @@ export const useRangeSlider = ({
       }
 
       return {
-        ...pickObject(rest, formControlProperties),
+        ...pickObject(
+          rest,
+          getFormControlProperties({ omit: ["aria-readonly"] }),
+        ),
         ...props,
         id: `slider-filled-track-${id}`,
         ref,
@@ -528,7 +540,10 @@ export const useRangeSlider = ({
         }
 
         return {
-          ...pickObject(rest, formControlProperties),
+          ...pickObject(
+            rest,
+            getFormControlProperties({ omit: ["aria-readonly"] }),
+          ),
           ...props,
           ref,
           id: getMarkerId(props.value),

--- a/packages/components/slider/src/slider.tsx
+++ b/packages/components/slider/src/slider.tsx
@@ -16,6 +16,7 @@ import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
   useFormControlProps,
   formControlProperties,
+  getFormControlProperties,
 } from "@yamada-ui/form-control"
 import { useControllableState } from "@yamada-ui/use-controllable-state"
 import { useLatestRef } from "@yamada-ui/use-latest-ref"
@@ -41,7 +42,7 @@ import {
   omitChildren,
   includesChildren,
 } from "@yamada-ui/utils"
-import type { CSSProperties, KeyboardEvent } from "react"
+import type { CSSProperties, KeyboardEvent, KeyboardEventHandler } from "react"
 import { useCallback, useRef, useState } from "react"
 
 export type UseSliderProps = FormControlOptions & {
@@ -281,7 +282,7 @@ export const useSlider = ({
     (ev: KeyboardEvent<HTMLElement>) => {
       const { min, max } = latestRef.current
 
-      const actions: Record<string, React.KeyboardEventHandler> = {
+      const actions: Record<string, KeyboardEventHandler> = {
         ArrowRight: () => stepUp(),
         ArrowUp: () => stepUp(),
         ArrowLeft: () => stepDown(),
@@ -331,7 +332,12 @@ export const useSlider = ({
       }
 
       return {
-        ...omitObject(rest, ["value", "onChangeStart", "onChangeEnd"]),
+        ...omitObject(rest, [
+          "aria-readonly",
+          "value",
+          "onChangeStart",
+          "onChangeEnd",
+        ]),
         ...props,
         ref: mergeRefs(ref, containerRef),
         tabIndex: -1,
@@ -376,7 +382,10 @@ export const useSlider = ({
       }
 
       return {
-        ...pickObject(rest, formControlProperties),
+        ...pickObject(
+          rest,
+          getFormControlProperties({ omit: ["aria-readonly"] }),
+        ),
         ...props,
         ref: mergeRefs(ref, trackRef),
         style,
@@ -408,7 +417,10 @@ export const useSlider = ({
       }
 
       return {
-        ...pickObject(rest, formControlProperties),
+        ...pickObject(
+          rest,
+          getFormControlProperties({ omit: ["aria-readonly"] }),
+        ),
         ...props,
         ref,
         style,
@@ -431,7 +443,10 @@ export const useSlider = ({
         }
 
         return {
-          ...pickObject(rest, formControlProperties),
+          ...pickObject(
+            rest,
+            getFormControlProperties({ omit: ["aria-readonly"] }),
+          ),
           ...props,
           ref,
           "aria-hidden": true,


### PR DESCRIPTION
Closes #583

## Description

`Slider` and `RangeSlider` must only use allowed ARIA attributes.

## Current behavior (updates)

When setting `isReadonly` to `Slider` or `RangeSlider` components, `aria-readonly` is assigned to unnecessary elements.

## New behavior

Removed unnecessary `aria-readonly`.

## Is this a breaking change (Yes/No):

No