### PR TITLE
fix: not close tooltip on click

### DIFF
--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -76,7 +76,7 @@ type TooltipOptions = {
   /**
    * If `true`, the tooltip will hide on click.
    *
-   * @default true
+   * @default false
    */
   closeOnClick?: boolean
   /**
@@ -191,7 +191,7 @@ export const Tooltip = forwardRef<TooltipProps, "div">(
       openDelay = 0,
       closeDelay = 0,
       isDisabled,
-      closeOnClick = true,
+      closeOnClick,
       closeOnScroll,
       closeOnMouseDown,
       closeOnEsc = true,


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #603 

## Description

> Fix bug . Tooltip should be not closed when click on trigger element. 

## Current behavior (updates)

> Currently, when click on trigger element the tooltip will be hidden

## New behavior

> Tooltip not being hidden when click trigger element.

## Is this a breaking change (Yes/No):

> no 

## Additional Information

https://github.com/hirotomoyamada/yamada-ui/assets/78476413/1704638a-18f1-4543-91ea-1807967f4c7a
