### PR TITLE
Fixed a bug in `RangeDatePicker`

### DIFF
--- a/.changeset/early-planets-repair.md
+++ b/.changeset/early-planets-repair.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/calendar": patch
+---
+
+Fixed a bug where `hiddenOutsideDays` was not working.

--- a/.changeset/seven-apples-sleep.md
+++ b/.changeset/seven-apples-sleep.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/calendar": patch
+---
+
+Added `defaultValue` to `RangeDatePicker`.

--- a/packages/components/calendar/src/multi-date-picker.tsx
+++ b/packages/components/calendar/src/multi-date-picker.tsx
@@ -93,7 +93,7 @@ export type MultiDatePickerProps = ThemeProps<"DatePicker"> &
   UseMultiDatePickerProps
 
 /**
- * `MultiDatePicker` is a component used for users to select multiple date.
+ * `MultiDatePicker` is a component used for users to select multiple dates.
  *
  * @see Docs https://yamada-ui.com/components/forms/multi-date-picker
  */

--- a/packages/components/calendar/src/use-calendar-picker.ts
+++ b/packages/components/calendar/src/use-calendar-picker.ts
@@ -173,6 +173,7 @@ export const useCalendarPicker = <T extends UseCalendarProps<any>>(
     paginateBy,
     withWeekdays,
     disableOutsideDays,
+    hiddenOutsideDays,
     minDate,
     maxDate,
     locale,
@@ -449,6 +450,7 @@ export const useCalendarPicker = <T extends UseCalendarProps<any>>(
       paginateBy,
       withWeekdays,
       disableOutsideDays,
+      hiddenOutsideDays,
       yearFormat,
       monthFormat,
       weekdayFormat,
@@ -476,6 +478,7 @@ export const useCalendarPicker = <T extends UseCalendarProps<any>>(
       enableRange,
     }),
     [
+      hiddenOutsideDays,
       maxSelectValues,
       enableMultiple,
       enableRange,

--- a/packages/components/calendar/src/use-range-date-picker.ts
+++ b/packages/components/calendar/src/use-range-date-picker.ts
@@ -42,7 +42,7 @@ export type UseRangeDatePickerProps = UseCalendarPickerProps<CalendarProps> &
 
 export const useRangeDatePicker = ({
   value: valueProp,
-  defaultValue,
+  defaultValue = [],
   onChange: onChangeProp,
   placeholder,
   startPlaceholder,
@@ -127,7 +127,7 @@ export const useRangeDatePicker = ({
       rest.onClick?.(ev)
     },
     onClose: () => {
-      const [startValue, endValue] = draftValue.current ?? value
+      const [startValue, endValue] = draftValue.current ?? value ?? []
 
       setStartInputValue(dateToString(startValue) ?? "")
       setEndInputValue(dateToString(endValue) ?? "")

--- a/stories/components/forms/date-picker.stories.tsx
+++ b/stories/components/forms/date-picker.stories.tsx
@@ -435,6 +435,10 @@ export const disabledWeekdays: Story = () => {
   return <DatePicker placeholder="YYYY/MM/DD" withWeekdays={false} />
 }
 
+export const hiddenOutsideDays: Story = () => {
+  return <DatePicker placeholder="YYYY/MM/DD" hiddenOutsideDays />
+}
+
 export const customIcon: Story = () => {
   return (
     <>

--- a/stories/components/forms/multi-date-picker.stories.tsx
+++ b/stories/components/forms/multi-date-picker.stories.tsx
@@ -473,6 +473,10 @@ export const disabledWeekdays: Story = () => {
   return <MultiDatePicker placeholder="YYYY/MM/DD" withWeekdays={false} />
 }
 
+export const hiddenOutsideDays: Story = () => {
+  return <MultiDatePicker placeholder="YYYY/MM/DD" hiddenOutsideDays />
+}
+
 export const customIcon: Story = () => {
   return (
     <>

--- a/stories/components/forms/range-date-picker.stories.tsx
+++ b/stories/components/forms/range-date-picker.stories.tsx
@@ -458,6 +458,10 @@ export const disabledWeekdays: Story = () => {
   return <RangeDatePicker placeholder="YYYY/MM/DD" withWeekdays={false} />
 }
 
+export const hiddenOutsideDays: Story = () => {
+  return <RangeDatePicker placeholder="YYYY/MM/DD" hiddenOutsideDays />
+}
+
 export const customIcon: Story = () => {
   return (
     <>


### PR DESCRIPTION
Close #619
Close #618

## Description

> Add a brief description

## Current behavior (updates)

`hiddenOutsideDays` can not be set with `DatePicker` or `MultiDatePicker`.

## New behavior

Added `hiddenOutsideDays` to `getCalendarProps` in `useCalendarPicker`.

## Is this a breaking change (Yes/No):

No

## Additional Information
