### PR TITLE
fix(tooltip): Tooltip onClose prop triggers on both open and close #630

### DIFF
--- a/.changeset/afraid-candles-carry.md
+++ b/.changeset/afraid-candles-carry.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/tooltip": major
+---
+
+fix Tooltip component onClose prop fires both when Tooltip component opens and closes

--- a/packages/components/tooltip/src/tooltip.tsx
+++ b/packages/components/tooltip/src/tooltip.tsx
@@ -229,13 +229,13 @@ export const Tooltip = forwardRef<TooltipProps, "div">(
 
     const openWithDelay = useCallback(() => {
       if (!isDisabled && !openTimeout.current) {
-        closeNow()
+        if (isOpen) closeNow()
 
         const win = getOwnerWindow(triggerRef.current)
 
         openTimeout.current = win.setTimeout(onOpen, openDelay)
       }
-    }, [isDisabled, openDelay, closeNow, onOpen])
+    }, [isDisabled, isOpen, openDelay, closeNow, onOpen])
 
     const closeWithDelay = useCallback(() => {
       if (openTimeout.current) {


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #630

## Description

fixed(tooltip) : Tooltip component onClose prop triggers on both open and close

## Current behavior (updates)

Tooltip component onClose triggers on both open and close

## New behavior

Tooltip component onClose triggers only on close

## Is this a breaking change (Yes/No):

No

## Additional Information
