### PR TITLE
fix: crossOrigin does not exist in Avatar

### DIFF
--- a/.changeset/thin-buttons-decide.md
+++ b/.changeset/thin-buttons-decide.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/avatar": major
+---
+
+fix crossOrigin does not exist in Avatar component

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -89,6 +89,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
     rounded = "full",
     onError,
     onLoad,
+    crossOrigin,
     format,
     children,
     ...rest
@@ -128,6 +129,7 @@ export const Avatar = forwardRef<AvatarProps, "span">((props, ref) => {
           rounded={rounded}
           onLoad={handlerAll(onLoad, () => setIsLoaded(true))}
           onError={onError}
+          crossOrigin={crossOrigin}
           format={format}
           name={name}
           icon={icon}

--- a/packages/components/avatar/src/avatar.tsx
+++ b/packages/components/avatar/src/avatar.tsx
@@ -67,7 +67,7 @@ type AvatarOptions = {
 export type AvatarProps = HTMLUIProps<"span"> &
   ThemeProps<"Avatar"> &
   AvatarOptions &
-  Pick<UseImageProps, "onLoad" | "onError">
+  Pick<UseImageProps, "onLoad" | "onError" | "crossOrigin">
 
 /**
  * `Avatar` is a component that displays a profile picture or an icon with initials representing a user.


### PR DESCRIPTION
Closes #629

## Description

> Avatar component renders img internally but does not support crossOrigin.

## Current behavior (updates)

> Avatar component don't have 'crossOrigin'

## New behavior

> Avatar component have 'crossOrigin'

## Is this a breaking change (Yes/No):

No

## Additional Information
