### PR TITLE
Fixed `ColorPicker` component `isReadOnly` style

### DIFF
--- a/.changeset/serious-insects-develop.md
+++ b/.changeset/serious-insects-develop.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where placeholder of `isReadOnly` style is reset.

--- a/packages/theme/src/components/color-picker.ts
+++ b/packages/theme/src/components/color-picker.ts
@@ -14,9 +14,6 @@ export const ColorPicker: ComponentMultiStyle = mergeMultiStyle(Input, Menu, {
       },
       _readOnly: {
         pointerEvents: "none",
-        _placeholder: {
-          color: "inherit !important",
-        },
       },
     },
     swatch: {},

--- a/packages/theme/src/components/date-picker.ts
+++ b/packages/theme/src/components/date-picker.ts
@@ -17,9 +17,6 @@ export const DatePicker: ComponentMultiStyle = mergeMultiStyle(
         },
         _readOnly: {
           pointerEvents: "none",
-          _placeholder: {
-            color: "inherit !important",
-          },
         },
       },
       list: {

--- a/packages/theme/src/components/native-select.ts
+++ b/packages/theme/src/components/native-select.ts
@@ -14,9 +14,6 @@ export const NativeSelect: ComponentMultiStyle = mergeMultiStyle(Input, {
       },
       _readOnly: {
         pointerEvents: "none",
-        _placeholder: {
-          color: "inherit !important",
-        },
       },
     },
     icon: {


### PR DESCRIPTION
Closes #665

## Description

When set `isReadOnly` to `ColorPicker` component, the placeholder style is reset.

## Current behavior (updates)

`important!` was used in the placeholder style.

## New behavior

Removed `important!`.

## Is this a breaking change (Yes/No):

No