### PR TITLE
fix(color-picker): alpha value is displayed when default-color is set

### DIFF
--- a/.changeset/purple-paws-peel.md
+++ b/.changeset/purple-paws-peel.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+Alpha value is displayed when default-color is set

--- a/packages/components/color-picker/src/use-color-picker.ts
+++ b/packages/components/color-picker/src/use-color-picker.ts
@@ -169,7 +169,9 @@ export const useColorPicker = ({
     defaultValue,
     onChange: onChangeProp,
   })
-  const formatRef = useRef<ColorFormat>(format ?? calcFormat(value ?? ""))
+  const formatRef = useRef<ColorFormat>(
+    format ?? calcFormat(value ?? defaultColor ?? ""),
+  )
   const isInputFocused = useRef<boolean>(false)
   const [inputValue, setInputValue] = useState<string>(value ?? "")
   const [isOpen, setIsOpen] = useState<boolean>(defaultIsOpen ?? false)


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #671

## Description

Alpha value is not displayed even if defaultColor is set

## Current behavior (updates)

`calcFormat` return `hex` when only defaultColor is set

## New behavior

Pass the `defaultColor` as an argument to `calcFormat` when `defaultColor` is set

## Is this a breaking change (Yes/No):

No

## Additional Information
