### PR TITLE
chore: add .idea to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ dist
 .DS_Store
 *.pem
 .vscode
+.idea
 
 # debug
 logs


### PR DESCRIPTION
Closes #690 

## Description

Added `.idea` to `.gitignore` file

## Current behavior (updates)

When using WebStorm by JetBrains, it creates some project settings in the `.idea` folder, which should not be added to staged changes.

## New behavior

`.idea` folder is now ignored by git.

## Is this a breaking change (Yes/No): No
