### PR TITLE
Fixed to remove unnecessary `aria-readonly`

### DIFF
--- a/.changeset/real-needles-applaud.md
+++ b/.changeset/real-needles-applaud.md
@@ -1,0 +1,10 @@
+---
+"@yamada-ui/segmented-control": patch
+"@yamada-ui/native-select": patch
+"@yamada-ui/autocomplete": patch
+"@yamada-ui/pin-input": patch
+"@yamada-ui/calendar": patch
+"@yamada-ui/checkbox": patch
+---
+
+Removed unnecessary `aria-readonly`

--- a/packages/components/autocomplete/src/use-autocomplete.tsx
+++ b/packages/components/autocomplete/src/use-autocomplete.tsx
@@ -2,7 +2,7 @@ import type { CSSUIObject, HTMLUIProps, UIPropGetter } from "@yamada-ui/core"
 import { layoutStyleProperties } from "@yamada-ui/core"
 import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
-  formControlProperties,
+  getFormControlProperties,
   useFormControlProps,
 } from "@yamada-ui/form-control"
 import type { MotionUIPropGetter } from "@yamada-ui/motion"
@@ -366,7 +366,10 @@ export const useAutocomplete = <T extends string | string[] = string>({
 
   const { id } = rest
 
-  const formControlProps = pickObject(rest, formControlProperties)
+  const formControlProps = pickObject(
+    rest,
+    getFormControlProperties({ omit: ["aria-readonly"] }),
+  )
   const [containerProps, inputProps] = splitObject<Dict, string>(
     omitObject(rest, [
       ...popoverProperties,
@@ -376,6 +379,7 @@ export const useAutocomplete = <T extends string | string[] = string>({
       "onChange",
       "onCreate",
       "onSearch",
+      "aria-readonly",
     ]),
     layoutStyleProperties,
   )

--- a/packages/components/calendar/src/use-calendar-picker.ts
+++ b/packages/components/calendar/src/use-calendar-picker.ts
@@ -8,7 +8,7 @@ import type {
 import {
   useFormControlProps,
   type FormControlOptions,
-  formControlProperties,
+  getFormControlProperties,
 } from "@yamada-ui/form-control"
 import { popoverProperties, type PopoverProps } from "@yamada-ui/popover"
 import { useOutsideClick } from "@yamada-ui/use-outside-click"
@@ -210,10 +210,13 @@ export const useCalendarPicker = <T extends UseCalendarProps<any>>(
 
   locale ??= theme.__config.date?.locale ?? "en"
 
-  const formControlProps = pickObject(rest, formControlProperties)
+  const formControlProps = pickObject(
+    rest,
+    getFormControlProperties({ omit: ["aria-readonly"] }),
+  )
   const [containerProps, inputProps] = splitObject<Dict, string>(
     omitObject(rest, [...popoverProperties]),
-    layoutStyleProperties,
+    [...layoutStyleProperties, "aria-readonly"],
   )
   const { disabled, readOnly } = formControlProps
 

--- a/packages/components/checkbox/src/checkbox.tsx
+++ b/packages/components/checkbox/src/checkbox.tsx
@@ -9,7 +9,6 @@ import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
   useFormControl,
   useFormControlProps,
-  formControlProperties,
   getFormControlProperties,
 } from "@yamada-ui/form-control"
 import type { SVGMotionProps } from "@yamada-ui/motion"
@@ -212,7 +211,10 @@ export const useCheckbox = <Y extends string | number = string>(
 
   const getIconProps: UIPropGetter = useCallback(
     (props = {}, ref = null) => ({
-      ...pickObject(rest, formControlProperties),
+      ...pickObject(
+        rest,
+        getFormControlProperties({ omit: ["aria-readonly"] }),
+      ),
       ...props,
       ref,
       "data-active": dataAttr(isActive),
@@ -244,7 +246,10 @@ export const useCheckbox = <Y extends string | number = string>(
 
   const getInputProps: UIPropGetter = useCallback(
     (props = {}, ref = null) => ({
-      ...pickObject(rest, formControlProperties),
+      ...pickObject(
+        rest,
+        getFormControlProperties({ omit: ["aria-readonly"] }),
+      ),
       ...props,
       ref: mergeRefs(inputRef, ref),
       id,

--- a/packages/components/checkbox/tests/checkbox.test.tsx
+++ b/packages/components/checkbox/tests/checkbox.test.tsx
@@ -50,7 +50,10 @@ describe("<Checkbox />", () => {
     )
     expect(
       screen.getByTestId("Checkbox").querySelector("input"),
-    ).toHaveAttribute("aria-readonly", "true")
+    ).not.toHaveAttribute("aria-readonly", "true")
+    expect(
+      screen.getByTestId("Checkbox").querySelector("input"),
+    ).not.toHaveAttribute("readonly", "true")
   })
 
   test("should be invalid", () => {

--- a/packages/components/native-select/src/native-select.tsx
+++ b/packages/components/native-select/src/native-select.tsx
@@ -9,7 +9,7 @@ import {
 import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
   useFormControlProps,
-  formControlProperties,
+  getFormControlProperties,
 } from "@yamada-ui/form-control"
 import { ChevronIcon } from "@yamada-ui/icon"
 import {
@@ -19,6 +19,7 @@ import {
   getValidChildren,
   isValidElement,
   pickObject,
+  omitObject,
 } from "@yamada-ui/utils"
 import type {
   DetailedHTMLProps,
@@ -121,8 +122,14 @@ export const NativeSelect = forwardRef<NativeSelectProps, "select">(
 
     rest = useFormControlProps(rest)
 
-    const formControlProps = pickObject(rest, formControlProperties)
-    const [layoutProps, selectProps] = splitObject(rest, layoutStyleProperties)
+    const formControlProps = pickObject(
+      rest,
+      getFormControlProperties({ omit: ["aria-readonly"] }),
+    )
+    const [layoutProps, selectProps] = splitObject(
+      omitObject(rest, ["aria-readonly"]),
+      layoutStyleProperties,
+    )
 
     let computedChildren: ReactElement[] = []
 

--- a/packages/components/native-select/tests/native-select.test.tsx
+++ b/packages/components/native-select/tests/native-select.test.tsx
@@ -62,10 +62,11 @@ describe("<NativeSelect />", () => {
 
   test("should be read only", () => {
     render(<NativeSelect isReadOnly data-testid="Select" />)
-    expect(screen.getByTestId("Select")).toHaveAttribute(
+    expect(screen.getByTestId("Select")).not.toHaveAttribute(
       "aria-readonly",
       "true",
     )
+    expect(screen.getByTestId("Select")).not.toHaveAttribute("readonly", "true")
   })
 
   test("should be invalid", () => {

--- a/packages/components/pin-input/src/pin-input.tsx
+++ b/packages/components/pin-input/src/pin-input.tsx
@@ -13,8 +13,8 @@ import {
 } from "@yamada-ui/core"
 import type { FormControlOptions } from "@yamada-ui/form-control"
 import {
+  getFormControlProperties,
   useFormControlProps,
-  formControlProperties,
 } from "@yamada-ui/form-control"
 import { useControllableState } from "@yamada-ui/use-controllable-state"
 import { createDescendant } from "@yamada-ui/use-descendant"
@@ -307,7 +307,10 @@ export const PinInput = forwardRef<PinInputProps, "div">(
         return {
           inputMode: type === "number" ? "numeric" : "text",
           type: mask ? "password" : type === "number" ? "tel" : "text",
-          ...pickObject(rest, formControlProperties),
+          ...pickObject(
+            rest,
+            getFormControlProperties({ omit: ["aria-readonly"] }),
+          ),
           ...filterUndefined(props),
           id: `${id}-${index}`,
           value: values[index] || "",

--- a/packages/components/segmented-control/src/segmented-control.tsx
+++ b/packages/components/segmented-control/src/segmented-control.tsx
@@ -188,7 +188,7 @@ export const SegmentedControl = forwardRef<SegmentedControlProps, "div">(
 
     const getContainerProps: UIPropGetter = useCallback(
       (props = {}, ref = null) => ({
-        ...omitObject(rest, ["onChange"]),
+        ...omitObject(rest, ["onChange", "aria-readonly"]),
         ...props,
         ref: mergeRefs(containerRef, ref),
         id,
@@ -209,7 +209,7 @@ export const SegmentedControl = forwardRef<SegmentedControlProps, "div">(
         const checked = props.value === selectedValue
 
         return {
-          ...omitObject(props, ["isDisabled", "isReadOnly"]),
+          ...omitObject(props, ["isDisabled", "isReadOnly", "aria-readonly"]),
           ref,
           id: `${id}-${index}`,
           type: "radio",


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
-->

Closes #591

## Description

Following components must only use allowed ARIA attributes.

- `DatePicker`
- `MonthPicker`
- `SegmentedControl`
- `MultiAutocomplete`
- `Autocomplete`
- `PinInput`
- `NativeSelect`
- `Checkbox`
- `Select`

## Current behavior (updates)

When setting isReadonly to the above components, aria-readonly is assigned to unnecessary elements.

## New behavior

Removed unnecessary `aria-readonly`.

## Is this a breaking change (Yes/No):

No
