### PR TITLE
Fix : Fixed a bug where fontSize of excessive numbers in AvatarGroup is not set to theme sizes.

### DIFF
--- a/.changeset/tasty-avocados-bake.md
+++ b/.changeset/tasty-avocados-bake.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where fontSize of excessive numbers in AvatarGroup is not set to theme sizes.

--- a/packages/theme/src/components/avatar.ts
+++ b/packages/theme/src/components/avatar.ts
@@ -40,7 +40,12 @@ export const Avatar: ComponentMultiStyle = {
         fontSize: `calc(${get(t, "sizes.4")} / 2.5)`,
         lineHeight: get(t, "sizes.16"),
       },
-      excess: { w: "4", h: "4" },
+      excess: {
+        w: "4",
+        h: "4",
+        fontSize: `calc(${get(t, "sizes.4")} / 2.5)`,
+        lineHeight: get(t, "sizes.16"),
+      },
     }),
     xs: ({ theme: t }) => ({
       container: {


### PR DESCRIPTION
Closes #631 

## Description
Fixed a bug where fontSize of excessive numbers in AvatarGroup is not set to theme sizes.

## Is this a breaking change (Yes/No):
No