### PR TITLE
fix:  `Button` component

### DIFF
--- a/.changeset/shy-geese-return.md
+++ b/.changeset/shy-geese-return.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/button": patch
+---
+
+Fixed `zIndex` and `gap` values

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -111,15 +111,13 @@ export const Button = forwardRef<ButtonProps, "button">(
 
     const css: CSSUIObject = useMemo(() => {
       const _focus =
-        "_focus" in styles
-          ? merge(styles._focus ?? {}, { zIndex: "yamcha" })
-          : {}
+        "_focus" in styles ? merge(styles._focus ?? {}, { zIndex: 1 }) : {}
 
       return {
         display: "inline-flex",
         alignItems: "center",
         justifyContent: "center",
-        gap: "2",
+        gap: "0.5rem",
         appearance: "none",
         userSelect: "none",
         position: "relative",


### PR DESCRIPTION
Closes #763 

## Description

Yamada UI allows you to use components without applying a theme. It is a mistake to use theme tokens inside components.

## Current behavior (updates)

```ts
merge(styles._focus ?? {}, { zIndex: "yamcha" })
```

```ts
gap: "2",
```

## New behavior

```ts
merge(styles._focus ?? {}, { zIndex: 1 })
```

```ts
gap: "0.5rem",
```

## Is this a breaking change (Yes/No):

No

