### PR TITLE
feat: added isRounded to the button

### DIFF
--- a/.changeset/feat-is-rounded.md
+++ b/.changeset/feat-is-rounded.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/button": patch
+---
+
+feat: added isRounded to the button

--- a/packages/components/button/src/button.tsx
+++ b/packages/components/button/src/button.tsx
@@ -21,6 +21,12 @@ type ButtonOptions = {
    */
   type?: "button" | "reset" | "submit"
   /**
+   * If true, the button is full rounded. Else, it'll be slightly round.
+   *
+   * @default false
+   */
+  isRounded?: boolean
+  /**
    * If `true`, the loading state of the button is represented.
    *
    * @default false
@@ -88,6 +94,7 @@ export const Button = forwardRef<ButtonProps, "button">(
       className,
       as,
       type,
+      isRounded,
       isLoading,
       isActive,
       isDisabled = group?.isDisabled,
@@ -130,8 +137,9 @@ export const Button = forwardRef<ButtonProps, "button">(
         ...styles,
         ...__css,
         ...(!!group ? { _focus } : {}),
+        ...(isRounded ? { borderRadius: "9999px" } : {}),
       }
-    }, [styles, __css, group])
+    }, [styles, __css, group, isRounded])
 
     const contentProps = {
       leftIcon,

--- a/packages/components/button/src/icon-button.tsx
+++ b/packages/components/button/src/icon-button.tsx
@@ -14,7 +14,6 @@ type IconButtonOptions = {
    *
    * @default false
    */
-  isRounded?: boolean
 }
 
 export type IconButtonProps = Omit<
@@ -29,13 +28,12 @@ export type IconButtonProps = Omit<
  * @see Docs https://yamada-ui.com/components/forms/icon-button
  */
 export const IconButton = forwardRef<IconButtonProps, "button">(
-  ({ icon, isRounded, children, className, ...rest }, ref) => {
+  ({ icon, children, className, ...rest }, ref) => {
     return (
       <Button
         className={cx("ui-icon-button", className)}
         ref={ref}
         p={0}
-        {...(isRounded ? { rounded: "full" } : {})}
         {...rest}
       >
         {icon || children}


### PR DESCRIPTION
Closes #759

## Description

> I added `isRounded` to the `ButtonOptions` type.
> I added the appropriate css style.
> I removed `isRounded` from `IconButton`, because it inherited from `Button`

## Current behavior (updates)

> `IconButton` has the `isRounded` props.

## New behavior

> `isRounded` inherited from the `Button`

## Is this a breaking change (Yes/No):

No
