### PR TITLE
fix(pin-input): some fixes about the asynchronous tests

### DIFF
--- a/packages/components/pin-input/tests/pin-input.test.tsx
+++ b/packages/components/pin-input/tests/pin-input.test.tsx
@@ -1,4 +1,4 @@
-import { a11y, render, screen, act, waitFor } from "@yamada-ui/test"
+import { a11y, act, render, screen, waitFor } from "@yamada-ui/test"
 import { PinInput } from "../src"
 
 describe("<PinInput />", () => {
@@ -27,10 +27,14 @@ describe("<PinInput />", () => {
     const { user } = render(<PinInput type="alphanumeric" />)
     const input = screen.getAllByRole("textbox")[0]
 
-    await user.tab()
-    await user.paste("a1")
+    await act(async () => {
+      await user.tab()
+      await user.paste("a1")
+    })
 
-    expect(input).toHaveValue("a1")
+    await waitFor(() => {
+      expect(input).toHaveValue("a1")
+    })
   })
 
   test("calls onChange and onComplete appropriately", async () => {
@@ -46,14 +50,22 @@ describe("<PinInput />", () => {
 
     const inputs = screen.getAllByRole("textbox")
 
-    await user.type(inputs[0], "1")
+    await act(async () => {
+      await user.type(inputs[0], "1")
+    })
 
-    expect(handleChange).toHaveBeenCalledWith("1")
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith("1")
+    })
 
-    await user.type(inputs[1], "2")
+    await act(async () => {
+      await user.type(inputs[1], "2")
+    })
 
-    expect(handleChange).toHaveBeenCalledWith("12")
-    expect(handleComplete).toHaveBeenCalledWith("12")
+    await waitFor(() => {
+      expect(handleChange).toHaveBeenCalledWith("12")
+      expect(handleComplete).toHaveBeenCalledWith("12")
+    })
   })
 
   test('input type should be "password" when mask is true', () => {
@@ -116,16 +128,22 @@ describe("<PinInput />", () => {
     const firstInput = inputs[0]
     const secondInput = inputs[1]
 
-    expect(firstInput.placeholder).toBe("○")
+    await waitFor(() => {
+      expect(firstInput.placeholder).toBe("○")
+    })
 
-    await user.tab()
+    await act(async () => {
+      await user.tab()
+    })
 
     await waitFor(() => {
       expect(document.activeElement).toBe(firstInput)
       expect(firstInput.placeholder).toBe("")
     })
 
-    await user.click(secondInput)
+    await act(async () => {
+      await user.click(secondInput)
+    })
 
     await waitFor(() => {
       expect(firstInput.placeholder).toBe("○")
@@ -140,12 +158,16 @@ describe("<PinInput />", () => {
     const inputs = screen.getAllByRole("textbox")
     const lastInput = inputs[3]
 
-    await user.click(lastInput)
-    await user.keyboard("[Backspace]")
+    await act(async () => {
+      await user.click(lastInput)
+      await user.keyboard("[Backspace]")
+    })
 
-    expect(document.activeElement).toEqual(inputs[2])
+    await waitFor(() => {
+      expect(document.activeElement).toEqual(inputs[2])
 
-    expect(inputs[2]).toHaveValue("")
+      expect(inputs[2]).toHaveValue("")
+    })
   })
 
   test("does not move focus on backspace if manageFocus is false", async () => {
@@ -154,10 +176,14 @@ describe("<PinInput />", () => {
     const inputs = screen.getAllByRole("textbox")
     const lastInput = inputs[3]
 
-    await user.click(lastInput)
-    await user.keyboard("[Backspace]")
+    await act(async () => {
+      await user.click(lastInput)
+      await user.keyboard("[Backspace]")
+    })
 
-    expect(document.activeElement).toEqual(lastInput)
+    await waitFor(() => {
+      expect(document.activeElement).toEqual(lastInput)
+    })
   })
 
   test("does not move focus if current input is not empty", async () => {
@@ -168,12 +194,16 @@ describe("<PinInput />", () => {
     const inputs = screen.getAllByRole("textbox")
     const thirdInput = inputs[2]
 
-    await user.click(thirdInput)
-    await user.keyboard("[Backspace]")
+    await act(async () => {
+      await user.click(thirdInput)
+      await user.keyboard("[Backspace]")
+    })
 
-    expect(document.activeElement).toEqual(thirdInput)
+    await waitFor(() => {
+      expect(document.activeElement).toEqual(thirdInput)
 
-    expect(thirdInput).toHaveValue("")
+      expect(thirdInput).toHaveValue("")
+    })
   })
 
   test("automatically focuses the first input on mount if autoFocus is true", async () => {
@@ -185,7 +215,9 @@ describe("<PinInput />", () => {
 
     const firstInput = screen.getAllByRole("textbox")[0]
 
-    expect(document.activeElement).toEqual(firstInput)
+    await waitFor(() => {
+      expect(document.activeElement).toEqual(firstInput)
+    })
   })
 
   test("does not focus the first input on mount if autoFocus is false", async () => {
@@ -195,7 +227,9 @@ describe("<PinInput />", () => {
 
     const firstInput = screen.getAllByRole("textbox")[0]
 
-    expect(document.activeElement).not.toEqual(firstInput)
+    await waitFor(() => {
+      expect(document.activeElement).not.toEqual(firstInput)
+    })
   })
 
   test("correct input behavior when pasting a value of 2 characters", async () => {
@@ -204,10 +238,14 @@ describe("<PinInput />", () => {
     const inputs = screen.getAllByRole("textbox")
     const firstInput = inputs[0]
 
-    await user.click(firstInput)
-    await user.paste("12")
+    await act(async () => {
+      await user.click(firstInput)
+      await user.paste("12")
+    })
 
-    expect(firstInput).toHaveValue("12")
+    await waitFor(() => {
+      expect(firstInput).toHaveValue("12")
+    })
   })
 
   test("correct input behavior when pasting a value of more than 2 characters", async () => {
@@ -216,11 +254,15 @@ describe("<PinInput />", () => {
 
     const inputs = screen.getAllByRole("textbox")
 
-    await user.tab()
-    await user.paste(testValue)
+    await act(async () => {
+      await user.tab()
+      await user.paste(testValue)
+    })
 
-    inputs.forEach((input, index) => {
-      expect(input).toHaveValue(testValue[index])
+    await waitFor(() => {
+      inputs.forEach((input, index) => {
+        expect(input).toHaveValue(testValue[index])
+      })
     })
   })
 
@@ -230,20 +272,28 @@ describe("<PinInput />", () => {
 
     const inputs = screen.getAllByRole("textbox")
 
-    await user.tab()
-    await user.type(inputs[0], "9")
+    await act(async () => {
+      await user.tab()
+      await user.type(inputs[0], "9")
+    })
 
-    expect(inputs[0]).toHaveValue("9")
-    expect(inputs[1]).toHaveValue("2")
-    expect(inputs[2]).toHaveValue("3")
-    expect(inputs[3]).toHaveValue("4")
+    await waitFor(() => {
+      expect(inputs[0]).toHaveValue("9")
+      expect(inputs[1]).toHaveValue("2")
+      expect(inputs[2]).toHaveValue("3")
+      expect(inputs[3]).toHaveValue("4")
+    })
 
-    await user.click(inputs[2])
-    await user.type(inputs[2], "{backspace}")
+    await act(async () => {
+      await user.click(inputs[2])
+      await user.type(inputs[2], "{backspace}")
+    })
 
-    expect(inputs[0]).toHaveValue("9")
-    expect(inputs[1]).toHaveValue("2")
-    expect(inputs[2]).toHaveValue("")
-    expect(inputs[3]).toHaveValue("4")
+    await waitFor(() => {
+      expect(inputs[0]).toHaveValue("9")
+      expect(inputs[1]).toHaveValue("2")
+      expect(inputs[2]).toHaveValue("")
+      expect(inputs[3]).toHaveValue("4")
+    })
   })
 })

--- a/packages/components/pin-input/tests/pin-input.test.tsx
+++ b/packages/components/pin-input/tests/pin-input.test.tsx
@@ -24,8 +24,10 @@ describe("<PinInput />", () => {
   })
 
   test('allows alphanumeric input when type is "alphanumeric"', async () => {
-    const { user } = render(<PinInput type="alphanumeric" />)
-    const input = screen.getAllByRole("textbox")[0]
+    const { user, findAllByRole } = render(<PinInput type="alphanumeric" />)
+
+    const inputs = await findAllByRole("textbox")
+    const firstInput = inputs[0]
 
     await act(async () => {
       await user.tab()
@@ -33,14 +35,14 @@ describe("<PinInput />", () => {
     })
 
     await waitFor(() => {
-      expect(input).toHaveValue("a1")
+      expect(firstInput).toHaveValue("a1")
     })
   })
 
   test("calls onChange and onComplete appropriately", async () => {
     const handleChange = jest.fn()
     const handleComplete = jest.fn()
-    const { user } = render(
+    const { user, findAllByRole } = render(
       <PinInput
         onChange={handleChange}
         onComplete={handleComplete}
@@ -48,7 +50,7 @@ describe("<PinInput />", () => {
       />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
 
     await act(async () => {
       await user.type(inputs[0], "1")
@@ -122,9 +124,9 @@ describe("<PinInput />", () => {
   })
 
   test("correct behavior on input focus", async () => {
-    const { user } = render(<PinInput />)
+    const { user, findAllByRole } = render(<PinInput />)
 
-    const inputs = screen.getAllByRole("textbox") as HTMLInputElement[]
+    const inputs = (await findAllByRole("textbox")) as HTMLInputElement[]
     const firstInput = inputs[0]
     const secondInput = inputs[1]
 
@@ -153,9 +155,11 @@ describe("<PinInput />", () => {
   })
 
   test("focus moves to previous input on backspace if current input is empty and manageFocus is true", async () => {
-    const { user } = render(<PinInput defaultValue="123" manageFocus={true} />)
+    const { user, findAllByRole } = render(
+      <PinInput defaultValue="123" manageFocus={true} />,
+    )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
     const lastInput = inputs[3]
 
     await act(async () => {
@@ -171,9 +175,11 @@ describe("<PinInput />", () => {
   })
 
   test("does not move focus on backspace if manageFocus is false", async () => {
-    const { user } = render(<PinInput defaultValue="123" manageFocus={false} />)
+    const { user, findAllByRole } = render(
+      <PinInput defaultValue="123" manageFocus={false} />,
+    )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
     const lastInput = inputs[3]
 
     await act(async () => {
@@ -187,11 +193,11 @@ describe("<PinInput />", () => {
   })
 
   test("does not move focus if current input is not empty", async () => {
-    const { user } = render(
+    const { user, findAllByRole } = render(
       <PinInput defaultValue="1234" items={4} manageFocus={true} />,
     )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
     const thirdInput = inputs[2]
 
     await act(async () => {
@@ -207,13 +213,14 @@ describe("<PinInput />", () => {
   })
 
   test("automatically focuses the first input on mount if autoFocus is true", async () => {
-    render(<PinInput autoFocus={true} />)
+    const { findAllByRole } = render(<PinInput autoFocus={true} />)
 
     await act(async () => {
       await new Promise((resolve) => requestAnimationFrame(resolve))
     })
 
-    const firstInput = screen.getAllByRole("textbox")[0]
+    const inputs = await findAllByRole("textbox")
+    const firstInput = inputs[0]
 
     await waitFor(() => {
       expect(document.activeElement).toEqual(firstInput)
@@ -221,11 +228,12 @@ describe("<PinInput />", () => {
   })
 
   test("does not focus the first input on mount if autoFocus is false", async () => {
-    render(<PinInput autoFocus={false} />)
+    const { findAllByRole } = render(<PinInput autoFocus={false} />)
 
     await new Promise((resolve) => requestAnimationFrame(resolve))
 
-    const firstInput = screen.getAllByRole("textbox")[0]
+    const inputs = await findAllByRole("textbox")
+    const firstInput = inputs[0]
 
     await waitFor(() => {
       expect(document.activeElement).not.toEqual(firstInput)
@@ -233,9 +241,9 @@ describe("<PinInput />", () => {
   })
 
   test("correct input behavior when pasting a value of 2 characters", async () => {
-    const { user } = render(<PinInput />)
+    const { user, findAllByRole } = render(<PinInput />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
     const firstInput = inputs[0]
 
     await act(async () => {
@@ -250,9 +258,9 @@ describe("<PinInput />", () => {
 
   test("correct input behavior when pasting a value of more than 2 characters", async () => {
     const testValue = "1234"
-    const { user } = render(<PinInput />)
+    const { user, findAllByRole } = render(<PinInput />)
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
 
     await act(async () => {
       await user.tab()
@@ -268,9 +276,11 @@ describe("<PinInput />", () => {
 
   test("the change in value does not impact other values", async () => {
     const defaultValue = "1234"
-    const { user } = render(<PinInput defaultValue={defaultValue} />)
+    const { user, findAllByRole } = render(
+      <PinInput defaultValue={defaultValue} />,
+    )
 
-    const inputs = screen.getAllByRole("textbox")
+    const inputs = await findAllByRole("textbox")
 
     await act(async () => {
       await user.tab()


### PR DESCRIPTION
## Description

Applied the following three fixes to the asynchronous tests in `@yamada-ui/pin-input`:

1. Added the necessary `await act(async() => {...})` where updates to React's state were missing.
3. Added the missing `await waitFor(() => {...})` for assertions in`test(async () => {})` statements.
4. Replaced with `getByXXXX` with `findByXXXX` for asynchronous tests.