### PR TITLE
fix(popover): some fixes about the asynchronous tests

### DIFF
--- a/packages/components/popover/tests/popover.test.tsx
+++ b/packages/components/popover/tests/popover.test.tsx
@@ -1,13 +1,13 @@
 import { Button, useDisclosure } from "@yamada-ui/react"
-import { a11y, render } from "@yamada-ui/test"
+import { a11y, act, render, screen } from "@yamada-ui/test"
 import {
   Popover,
-  PopoverTrigger,
   PopoverAnchor,
-  PopoverContent,
-  PopoverHeader,
   PopoverBody,
+  PopoverContent,
   PopoverFooter,
+  PopoverHeader,
+  PopoverTrigger,
 } from "../src"
 import type { PopoverProps } from "../src"
 
@@ -34,18 +34,20 @@ describe("<Popover />", () => {
   })
 
   test("should render popover", async () => {
-    const { getByRole, getByText, getByLabelText, user } = render(
+    const { findByRole, findByText, findByLabelText, user } = render(
       <PopoverExample />,
     )
-    const triggerButton = getByRole("button", { name: "Open Popover" })
+    const triggerButton = await findByRole("button", { name: "Open Popover" })
     expect(triggerButton).toBeVisible()
 
-    await user.click(triggerButton)
+    await act(async () => {
+      await user.click(triggerButton)
+    })
 
-    expect(getByLabelText("Close")).toBeVisible()
-    expect(getByText("Popover Header")).toBeVisible()
-    expect(getByText("Popover Body")).toBeVisible()
-    expect(getByText("Popover Footer")).toBeVisible()
+    expect(await findByLabelText("Close")).toBeVisible()
+    expect(await findByText("Popover Header")).toBeVisible()
+    expect(await findByText("Popover Body")).toBeVisible()
+    expect(await findByText("Popover Footer")).toBeVisible()
   })
 
   test("should render correctly with anchor text", async () => {
@@ -69,32 +71,36 @@ describe("<Popover />", () => {
       )
     }
 
-    const { getByRole, getByText, getByLabelText, user } = render(
+    const { findByRole, findByText, findByLabelText, user } = render(
       <PopoverWithAnchor />,
     )
-    const triggerButton = getByRole("button", { name: "Open Popover" })
+    const triggerButton = await findByRole("button", { name: "Open Popover" })
     expect(triggerButton).toBeVisible()
 
-    await user.click(triggerButton)
+    await act(async () => {
+      await user.click(triggerButton)
+    })
 
-    expect(getByText("Popover Header")).toBeVisible()
-    expect(getByText("anchor text")).toBeVisible()
-    expect(getByLabelText("Close")).toBeVisible()
-    expect(getByText("Popover Body")).toBeVisible()
-    expect(getByText("Popover Footer")).toBeVisible()
+    expect(await findByText("Popover Header")).toBeVisible()
+    expect(await findByText("anchor text")).toBeVisible()
+    expect(await findByLabelText("Close")).toBeVisible()
+    expect(await findByText("Popover Body")).toBeVisible()
+    expect(await findByText("Popover Footer")).toBeVisible()
   })
 
   test("should hover props work", async () => {
-    const { getByText, getByLabelText, user } = render(
+    const { findByText, findByLabelText, user } = render(
       <PopoverExample trigger="hover" />,
     )
 
-    await user.tab()
+    await act(async () => {
+      await user.tab()
+    })
 
-    expect(getByText("Popover Header")).toBeVisible()
-    expect(getByLabelText("Close")).toBeVisible()
-    expect(getByText("Popover Body")).toBeVisible()
-    expect(getByText("Popover Footer")).toBeVisible()
+    expect(await findByText("Popover Header")).toBeVisible()
+    expect(await findByLabelText("Close")).toBeVisible()
+    expect(await findByText("Popover Body")).toBeVisible()
+    expect(await findByText("Popover Footer")).toBeVisible()
   })
 
   test("can popover control", async () => {
@@ -119,21 +125,26 @@ describe("<Popover />", () => {
       )
     }
 
-    const { getByRole, getByText, getByLabelText, user } = render(
+    const { findByRole, findByText, findByLabelText, user } = render(
       <ControlPopover />,
     )
 
-    await user.click(getByRole("button", { name: "Open Popover" }))
+    const triggerButton = await findByRole("button", { name: "Open Popover" })
+    await act(async () => {
+      await user.click(triggerButton)
+    })
 
-    const closeButton = getByLabelText("Close")
-    expect(getByText("Popover Header")).toBeVisible()
+    const closeButton = await findByLabelText("Close")
+    expect(await findByText("Popover Header")).toBeVisible()
     expect(closeButton).toBeVisible()
-    expect(getByText("Popover Body")).toBeVisible()
+    expect(await findByText("Popover Body")).toBeVisible()
 
-    await user.click(closeButton)
+    await act(async () => {
+      await user.click(closeButton)
+    })
 
-    expect(getByText("Popover Header")).not.toBeVisible()
+    expect(await findByText("Popover Header")).not.toBeVisible()
     expect(closeButton).not.toBeVisible()
-    expect(getByText("Popover Body")).not.toBeVisible()
+    expect(await findByText("Popover Body")).not.toBeVisible()
   })
 })


### PR DESCRIPTION
## Description

Applied the following three fixes to the asynchronous tests in @yamada-ui/pin-input:

1. Added the necessary `await act(async() => {...})` where updates to React's state were missing.
2. Replaced with `getByXXXX` with `findByXXXX` for asynchronous tests.
