### PR TITLE
feat: added isRounded to the close-button

### DIFF
--- a/.changeset/grumpy-windows-mate.md
+++ b/.changeset/grumpy-windows-mate.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/close-button": patch
+---
+
+feat: added isRounded to the close-button

--- a/packages/components/close-button/src/close-button.tsx
+++ b/packages/components/close-button/src/close-button.tsx
@@ -22,6 +22,12 @@ type CloseButtonOptions = {
    * @default false
    */
   disableRipple?: boolean
+  /**
+   * If true, the button is full rounded.
+   *
+   * @default false
+   */
+  isRounded?: boolean
 }
 
 export type CloseButtonProps = HTMLUIProps<"button"> &
@@ -31,8 +37,15 @@ export type CloseButtonProps = HTMLUIProps<"button"> &
 export const CloseButton = forwardRef<CloseButtonProps, "button">(
   (props, ref) => {
     const [styles, mergedProps] = useComponentStyle("CloseButton", props)
-    const { className, children, isDisabled, __css, disableRipple, ...rest } =
-      omitThemeProps(mergedProps)
+    const {
+      className,
+      children,
+      isDisabled,
+      isRounded,
+      __css,
+      disableRipple,
+      ...rest
+    } = omitThemeProps(mergedProps)
     const { onPointerDown, ...rippleProps } = useRipple({
       ...rest,
       isDisabled: disableRipple || isDisabled,
@@ -48,6 +61,9 @@ export const CloseButton = forwardRef<CloseButtonProps, "button">(
       flexShrink: 0,
       ...styles,
       ...__css,
+      ...(isRounded
+        ? { borderRadius: "9999px", border: "1px solid #000" }
+        : {}),
     }
 
     return (

--- a/packages/components/close-button/src/close-button.tsx
+++ b/packages/components/close-button/src/close-button.tsx
@@ -62,7 +62,7 @@ export const CloseButton = forwardRef<CloseButtonProps, "button">(
       ...styles,
       ...__css,
       ...(isRounded
-        ? { borderRadius: "9999px", border: "1px solid #000" }
+        ? { borderRadius: "9999px", border: "1px solid currentColor" }
         : {}),
     }
 


### PR DESCRIPTION
Closes #760 

## Description

> I added `isRounded` to the `CloseButtonOptions` type.
> I added the appropriate css style. 
```ts
...(isRounded
        ? { borderRadius: "9999px", border: "1px solid #000" }
        : {}),
```

## Current behavior (updates)

> `CloseButton` does not have `isRounded`.

## New behavior

> `CloseButton has `isRounded`.

## Is this a breaking change (Yes/No):

No

