### PR TITLE
Fixed a bug where range slider thumb was not being applied

### DIFF
--- a/.changeset/odd-squids-tell.md
+++ b/.changeset/odd-squids-tell.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/slider": patch
+---
+
+Fixed a bug where range slider thumb was not being applied

--- a/packages/components/slider/src/range-slider.tsx
+++ b/packages/components/slider/src/range-slider.tsx
@@ -926,6 +926,8 @@ const RangeSliderThumb = forwardRef<
 
   const css: CSSUIObject = { ...styles.thumb }
 
+  const { children: propChildren } = thumbProps ?? {}
+
   return (
     <ui.div
       className={cx("ui-slider__thumb", className)}
@@ -942,7 +944,7 @@ const RangeSliderThumb = forwardRef<
       )}
     >
       <ui.input {...getInputProps({ ...inputProps, index }, ref)} />
-      {children}
+      {children ?? propChildren}
     </ui.div>
   )
 })


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #812 

## Description
Corrected an issue where range slider thumb icons were not shown.

## Current behavior (updates)
Icons are not applied
![image](https://github.com/hirotomoyamada/yamada-ui/assets/29009165/748c457e-1eb6-4e53-8367-ce9aef2d46d1)

## New behavior
Icons are applied
<img width="739" alt="image" src="https://github.com/hirotomoyamada/yamada-ui/assets/29009165/2e7f156d-8893-47c3-b076-53c2dc151f65">

## Is this a breaking change (Yes/No): 
No
<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->