### PR TITLE
Changed to correctly recognize `hex` values without `#`.

### DIFF
--- a/.changeset/tall-sheep-repeat.md
+++ b/.changeset/tall-sheep-repeat.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/utils": patch
+---
+
+Changed to correctly recognize `hex` values without `#`.

--- a/packages/utils/src/color.ts
+++ b/packages/utils/src/color.ts
@@ -207,6 +207,8 @@ export const convertColor =
     try {
       const isAlpha = format.endsWith("a")
 
+      if (/^[0-9a-fA-F]{6}$/.test(color)) color = "#" + color
+
       if (format.startsWith("hex")) {
         let hexa = c.toHex(color)
 
@@ -264,6 +266,8 @@ export const alphaToHex = (a: number) => {
 
 export const parseToRgba = (color: string, fallback?: string) => {
   try {
+    if (/^[0-9a-fA-F]{6}$/.test(color)) color = "#" + color
+
     return c.parseToRgba(color)
   } catch {
     if (fallback) return c.parseToRgba(fallback)
@@ -272,6 +276,8 @@ export const parseToRgba = (color: string, fallback?: string) => {
 
 export const parseToHsla = (color: string, fallback?: string) => {
   try {
+    if (/^[0-9a-fA-F]{6}$/.test(color)) color = "#" + color
+
     return c.parseToHsla(color)
   } catch {
     if (fallback) return c.parseToHsla(fallback)


### PR DESCRIPTION
Closes #829

## Description

Changed to correctly recognize `hex` values without `#`.

## Is this a breaking change (Yes/No):

No