### PR TITLE
Fix/color picker/tokens

### DIFF
--- a/.changeset/spicy-tools-rule.md
+++ b/.changeset/spicy-tools-rule.md
@@ -1,5 +1,5 @@
 ---
-"@yamada-ui/accordion": patch
+"@yamada-ui/color-picker": patch
 ---
 
 Fixed a bug where theme tokens were used in components.

--- a/.changeset/spicy-tools-rule.md
+++ b/.changeset/spicy-tools-rule.md
@@ -1,5 +1,5 @@
 ---
-"@yamada-ui/color-picker": patch
+"@yamada-ui/accordion": patch
 ---
 
 Fixed a bug where theme tokens were used in components.

--- a/.changeset/young-camels-drum.md
+++ b/.changeset/young-camels-drum.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+Fix a bug where theme tokens were used in color-picker components.

--- a/packages/components/color-picker/src/alpha-slider.tsx
+++ b/packages/components/color-picker/src/alpha-slider.tsx
@@ -169,8 +169,8 @@ export const AlphaSlider = forwardRef<AlphaSliderProps, "input">(
           className="ui-alpha-slider__track"
           __css={{
             position: "relative",
-            w: "full",
-            h: "full",
+            w: "100%",
+            h: "100%",
             ...styles.track,
           }}
           {...getTrackProps(trackProps)}

--- a/packages/components/color-picker/src/color-selector-body.tsx
+++ b/packages/components/color-picker/src/color-selector-body.tsx
@@ -59,7 +59,7 @@ export const ColorSelectorBody = forwardRef<ColorSelectorBodyProps, "div">(
 
     const css: CSSUIObject = {
       display: "flex",
-      w: "full",
+      w: "100%",
       ...styles.body,
     }
 

--- a/packages/components/color-picker/src/color-selector-swatches.tsx
+++ b/packages/components/color-picker/src/color-selector-swatches.tsx
@@ -1,5 +1,5 @@
-import type { CSSUIObject, HTMLUIProps, Token } from "@yamada-ui/core"
 import { forwardRef, ui } from "@yamada-ui/core"
+import type { CSSUIObject, HTMLUIProps, Token } from "@yamada-ui/core"
 import { cx, replaceObject } from "@yamada-ui/utils"
 import type { ReactNode } from "react"
 import type { ColorSwatchProps } from "./color-swatch"

--- a/packages/components/color-picker/src/color-selector-swatches.tsx
+++ b/packages/components/color-picker/src/color-selector-swatches.tsx
@@ -1,5 +1,5 @@
-import { forwardRef, ui } from "@yamada-ui/core"
 import type { CSSUIObject, HTMLUIProps, Token } from "@yamada-ui/core"
+import { forwardRef, ui } from "@yamada-ui/core"
 import { cx, replaceObject } from "@yamada-ui/utils"
 import type { ReactNode } from "react"
 import type { ColorSwatchProps } from "./color-swatch"
@@ -83,7 +83,7 @@ export const ColorSelectorSwatches = forwardRef<
               as="button"
               key={color}
               __css={{
-                boxSize: "full",
+                boxSize: "100%",
                 pointerEvents: readOnly ? "none" : undefined,
                 ...styles.swatch,
               }}

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -123,7 +123,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
       __css={css}
       {...rest}
     >
-      <ui.div {...(isRounded ? { rounded: "100%" } : {})}>
+      <ui.div {...(isRounded ? { rounded: "9999px" } : {})}>
         {overlays.map((props, index) => (
           <ui.div
             key={index}

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -1,10 +1,10 @@
+import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
 import {
-  ui,
   forwardRef,
   omitThemeProps,
+  ui,
   useMultiComponentStyle,
 } from "@yamada-ui/core"
-import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
 import { cx } from "@yamada-ui/utils"
 
 const defaultOverlays = (
@@ -123,7 +123,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
       __css={css}
       {...rest}
     >
-      <ui.div {...(isRounded ? { rounded: "100%" } : {})}>
+      <ui.div {...(isRounded ? { rounded: "9999px" } : {})}>
         {overlays.map((props, index) => (
           <ui.div
             key={index}

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -1,10 +1,10 @@
-import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
 import {
+  ui,
   forwardRef,
   omitThemeProps,
-  ui,
   useMultiComponentStyle,
 } from "@yamada-ui/core"
+import type { CSSUIObject, HTMLUIProps, ThemeProps } from "@yamada-ui/core"
 import { cx } from "@yamada-ui/utils"
 
 const defaultOverlays = (
@@ -123,7 +123,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
       __css={css}
       {...rest}
     >
-      <ui.div {...(isRounded ? { rounded: "9999px" } : {})}>
+      <ui.div {...(isRounded ? { rounded: "100%" } : {})}>
         {overlays.map((props, index) => (
           <ui.div
             key={index}

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -119,11 +119,11 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
     <ui.div
       ref={ref}
       className={cx("ui-color-swatch", className)}
-      {...(isRounded ? { rounded: "full" } : {})}
+      {...(isRounded ? { rounded: "100%" } : {})}
       __css={css}
       {...rest}
     >
-      <ui.div {...(isRounded ? { rounded: "full" } : {})}>
+      <ui.div {...(isRounded ? { rounded: "100%" } : {})}>
         {overlays.map((props, index) => (
           <ui.div
             key={index}
@@ -135,7 +135,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
               bottom: 0,
               ...styles.overlay,
             }}
-            {...(isRounded ? { rounded: "full" } : {})}
+            {...(isRounded ? { rounded: "100%" } : {})}
             {...props}
           />
         ))}

--- a/packages/components/color-picker/src/color-swatch.tsx
+++ b/packages/components/color-picker/src/color-swatch.tsx
@@ -119,7 +119,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
     <ui.div
       ref={ref}
       className={cx("ui-color-swatch", className)}
-      {...(isRounded ? { rounded: "100%" } : {})}
+      {...(isRounded ? { rounded: "9999px" } : {})}
       __css={css}
       {...rest}
     >
@@ -135,7 +135,7 @@ export const ColorSwatch = forwardRef<ColorSwatchProps, "div">((props, ref) => {
               bottom: 0,
               ...styles.overlay,
             }}
-            {...(isRounded ? { rounded: "100%" } : {})}
+            {...(isRounded ? { rounded: "9999px" } : {})}
             {...props}
           />
         ))}

--- a/packages/components/color-picker/src/hue-slider.tsx
+++ b/packages/components/color-picker/src/hue-slider.tsx
@@ -137,7 +137,7 @@ export const HueSlider = forwardRef<HueSliderProps, "input">((props, ref) => {
 
       <ui.div
         className="ui-hue-slider__track"
-        __css={{ position: "relative", w: "full", h: "full", ...styles.track }}
+        __css={{ position: "relative", w: "100%", h: "100%", ...styles.track }}
         {...getTrackProps(trackProps)}
       >
         <ui.div

--- a/packages/components/color-picker/src/saturation-slider.tsx
+++ b/packages/components/color-picker/src/saturation-slider.tsx
@@ -130,8 +130,8 @@ export const SaturationSlider = forwardRef<SaturationSliderProps, "input">(
             className="ui-saturation-slider__track"
             __css={{
               position: "relative",
-              w: "full",
-              h: "full",
+              w: "100%",
+              h: "100%",
               ...styles.track,
             }}
             {...getTrackProps(trackProps)}


### PR DESCRIPTION
Closes #842 

## Description

ColorPickerのtokensを具体値に修正しました。

## Current behavior (updates)
```
w: "full",
h: "full",
```

## New behavior
```
w: "100%",
h: "100%",
```
## Is this a breaking change (No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
