### PR TITLE
fix(resizable): fixed theme token usage in styles

### DIFF
--- a/.changeset/many-brooms-complain.md
+++ b/.changeset/many-brooms-complain.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/resizable": patch
+---
+
+Fixed a bug where theme tokens were used in components.

--- a/packages/components/resizable/src/resizable-item.tsx
+++ b/packages/components/resizable/src/resizable-item.tsx
@@ -49,7 +49,7 @@ export const ResizableItem = forwardRef<ResizableItemProps, "div">(
       ...rest,
     })
 
-    const css: CSSUIObject = { boxSize: "full", ...styles.item }
+    const css: CSSUIObject = { boxSize: "100%", ...styles.item }
 
     return (
       <UIPanel

--- a/packages/components/resizable/src/resizable.tsx
+++ b/packages/components/resizable/src/resizable.tsx
@@ -41,7 +41,7 @@ export const Resizable = forwardRef<ResizableProps, "div">(
       ...computedProps,
     })
 
-    const css: CSSUIObject = { w: "full", h: "full", ...styles.container }
+    const css: CSSUIObject = { w: "100%", h: "100%", ...styles.container }
 
     return (
       <ResizableProvider value={{ styles, ...rest }}>


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Hello!
I came across a tweet from Twitter (X) seeking contributions to this OSS project, and I felt compelled to get involved!
I've been following this repository for some time now, and I'm excited about the opportunity to contribute. I hope my changes can help improve the project. Looking forward to your feedback!

Closes #837  <!-- Github issue # here -->

## Description

Fixed a bug where theme tokens were used in components.
Replace `full` to `100%`

## Is this a breaking change (Yes/No):

No

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
