### PR TITLE
fix(inputelement): fixed theme token usage in styles

### DIFF
--- a/.changeset/wicked-colts-taste.md
+++ b/.changeset/wicked-colts-taste.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/input": patch
+---
+
+Fixed a bug where theme tokens were used in the InputElement component.

--- a/packages/components/input/src/input-element.tsx
+++ b/packages/components/input/src/input-element.tsx
@@ -37,7 +37,7 @@ const InputElement = forwardRef<InputElementProps, "div">(
         styles.field?.h ??
         styles.field?.minHeight ??
         styles.field?.minH,
-      h: "full",
+      h: "100%",
       fontSize: styles.field?.fontSize,
       pointerEvents: isClick ? "auto" : "none",
       cursor: isClick ? "pointer" : "auto",


### PR DESCRIPTION
Hi, this is the PR for fixing one of the theme token bug.

Closes #839 

## Description

Fixed a bug where theme tokens were used in components.
Replace full to 100%.

## Is this a breaking change (Yes/No):

No