### PR TITLE
Fixed a bug where when in dark mode, the focus border color of `Input` becomes thinner

### DIFF
--- a/.changeset/hot-donuts-clean.md
+++ b/.changeset/hot-donuts-clean.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/theme": patch
+---
+
+Fixed a bug where when in dark mode, the focus border color of `Input` becomes thinner.

--- a/packages/theme/src/components/input.ts
+++ b/packages/theme/src/components/input.ts
@@ -50,16 +50,16 @@ export const Input: ComponentMultiStyle = {
             userSelect: "all",
           },
           _invalid: {
-            borderColor: errorBorderColor,
+            borderColor: [errorBorderColor, errorBorderColor],
             boxShadow: `0 0 0 1px ${errorBorderColor}`,
           },
           _active: {
-            borderColor: focusBorderColor,
+            borderColor: [focusBorderColor, focusBorderColor],
             boxShadow: `0 0 0 1px ${focusBorderColor}`,
           },
           _focusVisible: {
             zIndex: "yamcha",
-            borderColor: focusBorderColor,
+            borderColor: [focusBorderColor, focusBorderColor],
             boxShadow: `0 0 0 1px ${focusBorderColor}`,
           },
         },
@@ -144,15 +144,15 @@ export const Input: ComponentMultiStyle = {
             userSelect: "all",
           },
           _invalid: {
-            borderColor: errorBorderColor,
+            borderColor: [errorBorderColor, errorBorderColor],
             boxShadow: `0px 1px 0px 0px ${errorBorderColor}`,
           },
           _active: {
-            borderColor: focusBorderColor,
+            borderColor: [focusBorderColor, focusBorderColor],
             boxShadow: `0px 1px 0px 0px ${focusBorderColor}`,
           },
           _focusVisible: {
-            borderColor: focusBorderColor,
+            borderColor: [focusBorderColor, focusBorderColor],
             boxShadow: `0px 1px 0px 0px ${focusBorderColor}`,
           },
         },


### PR DESCRIPTION
Closes #814

## Description

Fixed a bug where when in dark mode, the focus border color of `Input` becomes thinner.

## Is this a breaking change (Yes/No):

No