### PR TITLE
fix(calendar): fixed a bug where theme tokens were used in components

### DIFF
--- a/.changeset/good-crews-sip.md
+++ b/.changeset/good-crews-sip.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/calendar": patch
+---
+
+Fixed a bug where theme tokents were used in components.

--- a/packages/components/calendar/src/calendar-header.tsx
+++ b/packages/components/calendar/src/calendar-header.tsx
@@ -58,7 +58,7 @@ export const CalendarHeader: FC<CalendarHeaderProps> = ({
   const css: CSSUIObject = {
     display: "flex",
     alignItems: "center",
-    w: "full",
+    w: "100%",
     ...styles.header,
   }
   const { icon: iconElOrProps, ...computedLabelProps } = labelProps ?? {}

--- a/packages/components/calendar/src/date-picker.tsx
+++ b/packages/components/calendar/src/date-picker.tsx
@@ -191,7 +191,7 @@ export const DatePickerField = forwardRef<DatePickerFieldProps, "input">(
             ref={mergeRefs(ref, inputRef)}
             className="ui-date-picker__field__input"
             display="inline-block"
-            w="full"
+            w="100%"
             {...computedInputProps}
           />
         </ui.div>

--- a/packages/components/calendar/src/month.tsx
+++ b/packages/components/calendar/src/month.tsx
@@ -153,7 +153,7 @@ export const Month: FC<MonthProps> = ({
                           <ui.div
                             className="ui-calendar__month__weekday"
                             __css={{
-                              w: "full",
+                              w: "100%",
                               display: "flex",
                               ...styles.weekday,
                             }}


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #841

## Description
fullとなっていた幅設定を100％に修正しました

## Current behavior (updates)
`packages/components/calendar/src/calendar-header.tsx`
```tsx
const css: CSSUIObject = {
  display: 'flex',
  alignItems: 'center',
  w: 'full',
  ...styles.header,
};
```

`packages/components/calendar/src/date-picker.tsx`
```tsx
<ui.input
  ref={mergeRefs(ref, inputRef)}
  className='ui-date-picker__field__input'
  display='inline-block'
  w='full'
  {...computedInputProps}
/>
```

`packages/components/calendar/src/month.tsx`
```tsx
<ui.th
  key={index}
  __css={{
    fontWeight: 'normal',
    ...styles.cell,
  }}
  {...thProps}>
  <ui.div
    className='ui-calendar__month__weekday'
    __css={{
      w: 'full',
      display: 'flex',
      ...styles.weekday,
    }}
    {...computedWeekdayProps}>
    {customWeekday({ weekday, index })}
  </ui.div>
</ui.th>
```
## New behavior
`packages/components/calendar/src/calendar-header.tsx`
```tsx
const css: CSSUIObject = {
  display: 'flex',
  alignItems: 'center',
  w: '100%',
  ...styles.header,
};
```

`packages/components/calendar/src/date-picker.tsx`
```tsx
<ui.input
  ref={mergeRefs(ref, inputRef)}
  className='ui-date-picker__field__input'
  display='inline-block'
  w='100%'
  {...computedInputProps}
/>
```

`packages/components/calendar/src/month.tsx`
```tsx
<ui.th
  key={index}
  __css={{
    fontWeight: 'normal',
    ...styles.cell,
  }}
  {...thProps}>
  <ui.div
    className='ui-calendar__month__weekday'
    __css={{
      w: '100%',
      display: 'flex',
      ...styles.weekday,
    }}
    {...computedWeekdayProps}>
    {customWeekday({ weekday, index })}
  </ui.div>
</ui.th>
```
> Please describe the behavior or changes this PR adds

## Is this a breaking change (Yes/No): NOT

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
