### PR TITLE
fix:(Indicator) : theme token usage in styles 

### DIFF
--- a/.changeset/purple-adults-draw.md
+++ b/.changeset/purple-adults-draw.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/indicator": patch
+---
+
+fix:Indicator theme token usage in styles

--- a/packages/components/indicator/src/indicator.tsx
+++ b/packages/components/indicator/src/indicator.tsx
@@ -251,8 +251,8 @@ export const Indicator = forwardRef<IndicatorProps, "div">((props, ref) => {
               className="ui-indicator__icon__ping"
               __css={{
                 position: "absolute",
-                boxSize: "full",
-                rounded: "full",
+                boxSize: "100%",
+                rounded: "9999px",
                 opacity: 0.75,
                 zIndex: -1,
                 bg: pingColor,


### PR DESCRIPTION
<retry>
Hi!
Thanks for posting on Twitter!
I'm happy to try to contribute to this OSS for the first time.
We hope Yamada UI will be a success.

Closes:#840

## Description

I fixed a bug where theme tokens were used in components.
I replace from "full" to "100%".

## Is this a breaking change (Yes/No):

No
