### PR TITLE
test(a11y): remove unused type parameter

### DIFF
--- a/packages/test/src/accessibility.tsx
+++ b/packages/test/src/accessibility.tsx
@@ -7,7 +7,7 @@ import type { AxeMatchers } from "vitest-axe/matchers"
 import { render } from "./render"
 
 declare module "vitest" {
-  export interface Assertion<T = any> extends AxeMatchers {}
+  export interface Assertion extends AxeMatchers {}
   export interface AsymmetricMatchersContaining extends AxeMatchers {}
 }
 


### PR DESCRIPTION
## Description

* An unused type parameter was found in a statement extending Vitest matchers.

See: https://github.com/chaance/vitest-axe?tab=readme-ov-file#with-typescript