### PR TITLE
fix(autocomplete): theme tokens bug

### DIFF
--- a/.changeset/silent-windows-talk.md
+++ b/.changeset/silent-windows-talk.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": major
+---
+
+fixed a bug, autocomplete reference theme tokens

--- a/.changeset/silent-windows-talk.md
+++ b/.changeset/silent-windows-talk.md
@@ -1,5 +1,0 @@
----
-"@yamada-ui/autocomplete": major
----
-
-fixed a bug, autocomplete reference theme tokens

--- a/.changeset/tidy-ads-unite.md
+++ b/.changeset/tidy-ads-unite.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/autocomplete": patch
+---
+
+fixed a bug, autocomplete references theme tokens

--- a/packages/components/autocomplete/src/autocomplete.tsx
+++ b/packages/components/autocomplete/src/autocomplete.tsx
@@ -201,7 +201,7 @@ const AutocompleteField = forwardRef<AutocompleteFieldProps, "input">(
           <ui.input
             className="ui-autocomplete__field__input"
             display="inline-block"
-            w="full"
+            w="100%"
             placeholder={placeholder}
             {...getInputProps(
               { ...inputProps, value: inputValue || label || "" },


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes #832  <!-- Github issue # here -->

## Description

Autocompleteのtokensを具体的な値に変更しました

## Current behavior (updates)

```
w: "full",
```

## New behavior

```
w: "100%"
```

## Is this a breaking change (No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->

## Additional Information
