### PR TITLE
fix: use eyeDropperSupported for color-picker

### DIFF
--- a/.changeset/stupid-deers-exercise.md
+++ b/.changeset/stupid-deers-exercise.md
@@ -1,0 +1,5 @@
+---
+"@yamada-ui/color-picker": patch
+---
+
+use eyeDropperSupported for color-picker

--- a/packages/components/color-picker/src/color-picker.tsx
+++ b/packages/components/color-picker/src/color-picker.tsx
@@ -126,6 +126,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, "input">(
     } = omitThemeProps(omitObject(mergedProps, ["withSwatch"]))
     const {
       allowInput,
+      eyeDropperSupported,
       getPopoverProps,
       getContainerProps,
       getFieldProps,
@@ -170,7 +171,7 @@ export const ColorPicker = forwardRef<ColorPickerProps, "input">(
                 />
               </PopoverTrigger>
 
-              {withEyeDropper ? (
+              {eyeDropperSupported && withEyeDropper ? (
                 <ColorPickerEyeDropper
                   {...getEyeDropperProps(eyeDropperProps)}
                 />


### PR DESCRIPTION
<!---
Thanks for creating a Pull Request 💖!

Please read the following before submitting:
- PRs that adds new external dependencies might take a while to review.
- Keep your PR as small as possible.
- Limit your PR to one type (docs, feature, refactoring, ci, or bugfix)
- If a PR is not merged within one week of its creation, core members may intervene.
-->

Closes https://github.com/hirotomoyamada/yamada-ui/issues/862

## Description

> Add a brief description

Fixed colorPicker component to be displayed only in browsers that support eyedropper.


## Current behavior (updates)

> Please describe the current behavior that you are modifying

| safari (unsupported) | Chrome(supported) |
|--------|--------|
| <img width="891" alt="image" src="https://github.com/hirotomoyamada/yamada-ui/assets/83756829/4ea441e0-9413-4616-8257-d37ed50b3f93"> | <img width="891" alt="image" src="https://github.com/hirotomoyamada/yamada-ui/assets/83756829/ce7f6962-a31b-4447-92bf-a18cb866b914"> | 

## New behavior|
> Please describe the behavior or changes this PR adds

| safari (unsupported) | Chrome(supported) |
|--------|--------|
|<img width="889" alt="貼り付けた画像_2024_02_29_23_45" src="https://github.com/hirotomoyamada/yamada-ui/assets/83756829/db497b8a-b911-4781-82cf-738e3b1198f2">|<img width="893" alt="image" src="https://github.com/hirotomoyamada/yamada-ui/assets/83756829/36beec20-db08-49da-9ffd-b61bf65f595c"> 

## Is this a breaking change (Yes/No):

<!-- If Yes, please describe the impact and migration path for existing Yamada UI users. -->
No

## Additional Information
